### PR TITLE
reinitialization and individual parameter dispersion

### DIFF
--- a/bsfh/fitterutils.py
+++ b/bsfh/fitterutils.py
@@ -25,7 +25,7 @@ def run_emcee_sampler(lnprobf, initial_center, model,
         nwalkers = int(2 ** np.round(np.log2(ndim * walker_factor)))
     if verbose:
         print('number of walkers={}'.format(nwalkers))    
-    initial = sampler_ball(initial_center, initial_disp, nwalkers, model)
+    initial = sampler_ball(initial_center, model.theta_disps(initial_disp), nwalkers, model)
     # Initialize sampler
     esampler = emcee.EnsembleSampler(nwalkers, ndim, lnprobf,
                                      args=postargs, kwargs=postkwargs,

--- a/bsfh/fitterutils.py
+++ b/bsfh/fitterutils.py
@@ -114,6 +114,28 @@ def pminimize(chi2fn, initial, args=None,
 
     return [powell_guesses, pinitial]
 
+def reinitialize(best_guess,model, edge_trunc=0.1):
+    """Check if the Powell minimization found a minimum close to
+    the edge of the prior for any parameter. If so, reinitialize
+    to the center of the prior.
+
+    Avoid this step by inserting 'reinit:False' in model list of 
+    dictionaries.
+    """
+    bounds = model.theta_bounds()
+    output = np.zeros(len(best_guess))
+    reinit = [x.get('reinit', True) for x in model.config_list if x['name'] in model.theta_labels()]
+
+    for k in range(len(best_guess)):
+        parmrange = bounds[k][1]-bounds[k][0]
+        if (((best_guess[k]-bounds[k][0])/parmrange < edge_trunc) or \
+           ((bounds[k][1]-best_guess[k])/parmrange < edge_trunc)) and \
+           (reinit[k] == True):
+            output[k] = bounds[k][0]+parmrange/2.
+        else:
+            output[k] = best_guess[k]
+
+    return output
 
 def minimizer_ball(center, nminimizers, model):
     """Setup a 'grid' of parameter values uniformly distributed

--- a/bsfh/parameters.py
+++ b/bsfh/parameters.py
@@ -205,6 +205,9 @@ class ProspectrParams(object):
         bounds = [(np.atleast_1d(a)[0], np.atleast_1d(b)[0]) for a,b in bounds]        
         return bounds
 
+    def theta_disps(self, initial_disp):
+        return np.array([x.get('init_disp',initial_disp) for x in self.config_list if x['name'] in self.theta_labels()])
+
     
 def plist_to_pdict(inplist):
     """Convert from a parameter list to a parameter dictionary, where

--- a/demo/prospectr.py
+++ b/demo/prospectr.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     initial_theta = model.initial_theta
     if rp.get('debug', False):
         halt()
-        
+
     #################
     # Initial guesses using powell minimization
     #################
@@ -188,7 +188,9 @@ if __name__ == "__main__":
                                                 method ='powell', opts=powell_opt,
                                                 pool = pool, nthreads = rp.get('nthreads',1))
         best = np.argmin([p.fun for p in powell_guesses])
-        initial_center = powell_guesses[best].x
+        initial_center = utils.reinitialize(powell_guesses[best].x, model,
+                                            edge_trunc=rp.get('edge_trunc',0.1))
+
         pdur = time.time() - ts
         if rp['verbose']:
             print('done Powell in {0}s'.format(pdur))


### PR DESCRIPTION
Added a parameter reinitialization after the powell minimization step. It takes rp['edge_trunc'] as an argument, and if any parameter is within (prior max - prior min) * edge_trunc of a prior, it is reinitialized to the center. The default truncation value is 10%. You can specify 'reinit' = False in the list of parameter dictionaries to avoid reinitialization; I've found this useful in particular for mass, which always resets to the center because of the huge dynamic range.

Also added dispersion for each parameter, accessible by setting 'init_disp' in the list of parameter dictionaries.