### PR TITLE
Reinit tweaks

### DIFF
--- a/bsfh/fitterutils.py
+++ b/bsfh/fitterutils.py
@@ -116,13 +116,15 @@ def pminimize(chi2fn, initial, args=None,
 
     return [powell_guesses, pinitial]
 
-def reinitialize(best_guess, model, edge_trunc=0.1):
+def reinitialize(best_guess, model, edge_trunc=0.1,
+                 reinit_params = [], **extras):
     """Check if the Powell minimization found a minimum close to
     the edge of the prior for any parameter. If so, reinitialize
     to the center of the prior.
 
-    This is only done for parameters where 'reinit:True' in the model
-    configuration dictionary
+    This is only done for parameters where ``'reinit':True`` in the model
+    configuration dictionary, or for parameters in the supplied
+    ``reinit_params`` list.
 
     :param buest_guess:
         The result of some sort of optimization step, iterable of
@@ -135,16 +137,22 @@ def reinitialize(best_guess, model, edge_trunc=0.1):
         The fractional distance from the edge of the priors that
         triggers reinitialization.
 
+    :param reinit_params: optional
+        A list of model parameter names to reinitialize, overrides the
+        value or presence of the ``reinit`` key in the model
+        configuration dictionary.
+        
     :returns output:
         The best_guess with parameters near the edge reset to be at
         the center of the prior.  ndarray of shape (ndim,)
     """
-
+    edge = edge_trunc
     bounds = model.theta_bounds()
     output = np.array(best_guess)
     reinit = np.zeros(model.ndim, dtype= bool)
     for p, inds in model.theta_index.iteritems():
-        reinit[inds[0]:inds[1]] = model._config_dict[p].get('reinit', False)
+        reinit[inds[0]:inds[1]] = (model._config_dict[p].get('reinit', False)
+                                   or (p in reinit_params))
         
     for k, (guess, bound) in enumerate(zip(best_guess, bounds)):
         #normalize the guess and the bounds

--- a/bsfh/parameters.py
+++ b/bsfh/parameters.py
@@ -191,6 +191,12 @@ class ProspectrParams(object):
         pass
 
     def theta_bounds(self):
+        """Get the bounds on each parameter from the prior.
+
+        :returns bounds:
+            A list of length self.ndim of tuples (lo, hi) giving the parameter
+            bounds.
+        """
         bounds = self.ndim * [(0.,0.)]
         for p, v in self.theta_index.iteritems():
             sz = v[1] - v[0]
@@ -205,8 +211,21 @@ class ProspectrParams(object):
         bounds = [(np.atleast_1d(a)[0], np.atleast_1d(b)[0]) for a,b in bounds]        
         return bounds
 
-    def theta_disps(self, initial_disp):
-        return np.array([x.get('init_disp',initial_disp) for x in self.config_list if x['name'] in self.theta_labels()])
+    def theta_disps(self, initial_disp=0.1):
+        """Get a vector of (fractional) dispersions for each parameter to use in
+        generating sampler balls for emcee's Ensemble sampler.
+
+        :param initial_disp: (default: 0.1)
+            The default dispersion to use in case the `init_disp` key
+            is not provided in the parameter configuration.  This is
+            in units of the parameter, so e.g. 0.1 will result in a
+            smpler ball with a dispersion that is 10% of the central
+            parameter value.
+        """
+        disp = np.zeros(self.ndim) + initial_disp
+        for par, inds in self.theta_index.iteritems:
+            disp[inds[0]:inds[1]] = self._config_dict[par].get('init_disp', initial_disp)
+        return disp
 
     
 def plist_to_pdict(inplist):

--- a/bsfh/parameters.py
+++ b/bsfh/parameters.py
@@ -223,7 +223,7 @@ class ProspectrParams(object):
             parameter value.
         """
         disp = np.zeros(self.ndim) + initial_disp
-        for par, inds in self.theta_index.iteritems:
+        for par, inds in self.theta_index.iteritems():
             disp[inds[0]:inds[1]] = self._config_dict[par].get('init_disp', initial_disp)
         return disp
 

--- a/demo/demo_csphot_params.py
+++ b/demo/demo_csphot_params.py
@@ -168,6 +168,8 @@ model_params.append({'name': 'dust1', 'N': 1,
 model_params.append({'name': 'dust2', 'N': 1,
                         'isfree': True,
                         'init': 0.35,
+                        'reinit': True,
+                        'init_disp': 0.3,
                         'units': '',
                         'prior_function':tophat,
                         'prior_args': {'mini':0.0, 'maxi':2.0}})


### PR DESCRIPTION
This introduces some tweaks to the new code in #18, mostly to deal with parameters that can themselves be vectors, and also allowing a list of parameters to be reinitialized to be given directly to reinitialize() in addition to looking in the parameter dictionary for the relevant keyword.  The default is also changed to *no* reinitialization unless explicitly asked for by one of these two mechanisms.