### PR TITLE
More flexible photometric noise modeling

### DIFF
--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -15,52 +15,46 @@ class GaussianProcess(object):
             The uncertainty estimate at each wavelength point.
         """
         if kernel is None:
-            self.kernel = np.array([0.0, 0.0, 0.0])
+            npar = self.kernel_properties[0]
+            self.kernel = np.zeros(npar)
         else:
             self.kernel = kernel
-        #_params stores values of kernel parameter used to construct
-        #and compute the factorized covariance matrix
+        #_params stores the values of kernel parameters used to
+        #construct and compute the factorized covariance matrix that
+        #is stored in factorized_Sigma
         self._params = None
         self.wave = wave
         self.sigma = sigma
-        
-    def kernel_to_params(self, kernel):
-        """Kernel is a vector consisting of log(s, a**2, l**2)
-        """
-        s, asquared, lsquared = np.exp(kernel).tolist()
-        return s, asquared, lsquared
 
+    def reset(self):
+        self.factorized_Sigma = None
+        self.wave = None
+        self.sigma = None
+        self._params = None
+        self.kernel = None
+        
     @property
     def kernel_same(self):
-        s, asq, lsq = self.kernel_to_params(self.kernel)
-        kernel_same = (s == self.s) & (asq == self.asq) & (lsq == self.lsq)
-        return kernel_same
-
-    def construct_covariance(self, inwave=None, cross=False):
-
-        s, asq, lsq = self.params
-        
-        if inwave is None:
-            X_star = X = self.wave
-            Sigma = asq * np.exp(-(self.wave[:,None] - self.wave[None,:])**2/(2*lsq))
-            Sigma[np.diag_indices_from(Sigma)] += (self.sigma**2 + s**2)
-            return Sigma
-        elif cross:
-            Sigma = asq * np.exp(-(inwave[:,None] - self.wave[None,:])**2/(2*lsq))
-            return Sigma
-        else:
-            Sigma = asq * np.exp(-(inwave[:,None] - inwave[None,:])**2/(2*lsq))
-            Sigma[np.diag_indices_from(Sigma)] += s**2
-            return Sigma
-
+        params = self.kernel_to_params(self.kernel)
+        ksame = np.array_equal(params, self._params)
+        return ksame, params
+              
     def compute(self, wave=None, sigma=None, check_finite=False, force=False):
-        """
+        """Construct the covariance matrix, factorize it, and store
+        the factorized matrix.  The factorization is only performed if
+        the kernel parameters have chenged or the observational data
+        (wave and sigma) have changed.
+        
         :param wave: optional
-            independent variable
+            independent variable.
             
         :param sigma:
-            .
+            uncertainties on the dependent variable at the locations
+            of the independent variable
             
+        :param force: optional
+            If true, force a recomputation even if the kernel and the
+            data are the same as for the stored factorization.
         """
         if wave is None:
             wave = self.wave
@@ -69,9 +63,9 @@ class GaussianProcess(object):
         data_same = (np.all(wave == self.wave) &
                      np.all(sigma == self.sigma))
         params = self.kernel_to_params(self.kernel)
-        kernel_same = np.array_equal(params, self._params)
+        ksame, params = self.kernel_same()
 
-        if kernel_same and data_same and (not force):
+        if ksame and data_same and (not force):
             return
         
         else:
@@ -87,7 +81,8 @@ class GaussianProcess(object):
                             
     def lnlikelihood(self, residual, check_finite=False):
         """
-        Compute the ln of the likelihood, using the current factorized sigma
+        Compute the ln of the likelihood, using the current factorized
+        covariance matrix.
         
         :param residual: ndarray, shape (nwave,)
             Vector of residuals (y_data - mean_model).
@@ -103,13 +98,14 @@ class GaussianProcess(object):
               
     def predict(self, residual, wave=None):
         """
-        For a given residual vector, give the GP mean prediction at each wavelength.
+        For a given residual vector, give the GP mean prediction at
+        each wavelength and the covariance matrix.
 
         :param residual:
             Vector of residuals (y_data - mean_model).
             
         :param wave: default None
-            Wavelengths at which variance estimates are desired.
+            Wavelengths at which mean and variance estimates are desired.
             Defaults to the input wavelengths.
         """
         
@@ -121,4 +117,76 @@ class GaussianProcess(object):
         cov = Sigma_star - np.dot(Sigma_cross, cho_solve(self.factorized_Sigma,
                                                          -Sigma_cross.T))
         return mu, cov
+
+    @property
+    def kernel_properties(self):
+        """Return a list of kernel properties, where the first element
+        is the number of kernel parameters
+        """
+        raise NotImplementedError
+    
+    def kernel_to_params(self, kernel):
+        """A method that takes an ndarray and returns a blob of kernel
+        parameters.  mostly usied for a sort of documentation, but
+        also for grouping parameters
+        """
+        raise NotImplementedError
+    
+    def construct_covariance(self, inwave=None, cross=False):
+        raise NotImplementedError
+
+class ExpSquared(GaussianProcess):
+
+    @property
+    def kernel_properties(self):
+        return [3]
                               
+    def kernel_to_params(self, kernel):
+        """Kernel is a vector consisting of log(s, a**2, l**2)
+        """
+        s, asquared, lsquared = np.exp(kernel).tolist()
+        return s, asquared, lsquared
+
+    def construct_covariance(self, inwave=None, cross=False):
+        """Construct an exponential squared covariance matrix
+        """
+        s, asq, lsq = self._params
+        
+        if inwave is None:
+            Sigma = asq * np.exp(-(self.wave[:,None] - self.wave[None,:])**2/(2*lsq))
+            Sigma[np.diag_indices_from(Sigma)] += (self.sigma**2 + s**2)
+            return Sigma
+        elif cross:
+            Sigma = asq * np.exp(-(inwave[:,None] - self.wave[None,:])**2/(2*lsq))
+            return Sigma
+        else:
+            Sigma = asq * np.exp(-(inwave[:,None] - inwave[None,:])**2/(2*lsq))
+            Sigma[np.diag_indices_from(Sigma)] += s**2
+            return Sigma
+        
+class Outlier(GaussianProcess):
+
+    def kernel_properties(self):
+        return [2]
+    
+    def kernel_to_params(self, kernel):
+        """Kernel is a set of (diagonal) locations and amplitudes
+        """
+        assert ((len(kernel) % 2 == 0))
+        nout = len(kernel) / 2
+        locs, amps = kernel[np.arange(nout) * 2], kernel[np.arange(nout) * 2 + 1]
+        return locs, amps
+
+    def construct_covariance(self, inwave=None, cross=None):
+        locs, amps = self._params
+        locs = locs.astype(int)
+        if inwave is None:
+            nw = len(self.wave)
+            Sigma = np.zeros([nw, nw])
+            #diag = np.diag_indices_from(Sigma)
+            Sigma[(np.arange(nw), np.arange(nw))] += self.sigma**2
+            Sigma[(locs, locs)] += amps**2
+        else:
+            raise ValueError
+        
+        return Sigma

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -3,7 +3,7 @@ from scipy.linalg import cho_factor, cho_solve
 
 class GaussianProcess(object):
 
-    def __init__(self, wave=None, sigma=None, kernel=None, flux=1):
+    def __init__(self, wave=None, sigma=None, kernel=None, flux=1, **extras):
         """
         Initialize the relevant parameters for the gaussian process.
 
@@ -44,7 +44,8 @@ class GaussianProcess(object):
         ksame = np.array_equal(params, self._params)
         return ksame, params
               
-    def compute(self, wave=None, sigma=None, check_finite=False, force=False):
+    def compute(self, wave=None, sigma=None, check_finite=False,
+                force=False, **extras):
         """Construct the covariance matrix, factorize it, and store
         the factorized matrix.  The factorization is only performed if
         the kernel parameters have chenged or the observational data
@@ -67,7 +68,7 @@ class GaussianProcess(object):
             sigma = self.sigma
         data_same = (np.all(wave == self.wave) &
                      np.all(sigma == self.sigma))
-        params = self.kernel_to_params(self.kernel)
+        #params = self.kernel_to_params(self.kernel)
         ksame, params = self.kernel_same
 
         if ksame and data_same and (not force):
@@ -83,8 +84,8 @@ class GaussianProcess(object):
                                                 check_finite=check_finite)
             self.log_det = 2 * np.sum( np.log(np.diag(self.factorized_Sigma[0])))
             assert np.isfinite(self.log_det)
-                            
-    def lnlikelihood(self, residual, check_finite=False):
+
+    def lnlikelihood(self, residual, check_finite=False, **extras):
         """
         Compute the ln of the likelihood, using the current factorized
         covariance matrix.
@@ -92,12 +93,12 @@ class GaussianProcess(object):
         :param residual: ndarray, shape (nwave,)
             Vector of residuals (y_data - mean_model).
         """
-        assert ( len(residual) == len(self.wave))
+        assert ( len(residual) == len(self.sigma))
         self.compute()
         first_term = np.dot(residual,
                             cho_solve(self.factorized_Sigma,
                                       residual, check_finite = check_finite))
-        lnL=  -0.5* (first_term + self.log_det)
+        lnL=  -0.5 * (first_term + self.log_det)
         
         return lnL
               
@@ -115,10 +116,10 @@ class GaussianProcess(object):
         """
         
         
-        Sigma_cross = self.construct_covariance(wave=wave, cross=True)
-        Sigma_star = self.construct_covariance(wave=wave, cross=False)
+        Sigma_cross = self.construct_covariance(inwave=wave, cross=True)
+        Sigma_star = self.construct_covariance(inwave=wave, cross=False)
         
-        mu = np.dot(Sigma, cho_solve(self.factorized_Sigma, residual))
+        mu = np.dot(Sigma_cross, cho_solve(self.factorized_Sigma, residual))
         cov = Sigma_star - np.dot(Sigma_cross, cho_solve(self.factorized_Sigma,
                                                          -Sigma_cross.T))
         return mu, cov
@@ -152,7 +153,7 @@ class ExpSquared(GaussianProcess):
         s, asquared, lsquared = np.exp(kernel).tolist()
         return s, asquared, lsquared
 
-    def construct_covariance(self, inwave=None, cross=False):
+    def construct_covariance(self, inwave=None, cross=False, **extras):
         """Construct an exponential squared covariance matrix
         """
         s, asq, lsq = self._params
@@ -176,26 +177,30 @@ class PhotOutlier(GaussianProcess):
         return [3]
     
     def kernel_to_params(self, kernel):
-        """Kernel is a set of (diagonal) locations and amplitudes
+        """Kernel is a set of (diagonal) locations and amplitudes.
+        The last element is the jitter term.
         """
-        assert ((len(kernel) % 2 == 1))
-        nout = (len(kernel)-1) / 2
-        locs = np.exp(kernel[np.arange(nout) * 2])
-        amps = np.exp(kernel[np.arange(nout) * 2 + 1])
-        jitter = kernel[-1]
+        jitter = int((len(kernel) % 2 == 1))
+        nout = (len(kernel)-jitter) / 2
+        amps = kernel[:nout]
+        locs = kernel[nout:2*nout]
+        if jitter:
+            jitter = kernel[-1]
         return jitter, locs, amps
 
-    def construct_covariance(self, inwave=None, cross=None):
+    def construct_covariance(self, cross=None, **extras):
         jitter, locs, amps = self._params
         #round to the nearest index
         locs = locs.astype(int)
-        if inwave is None:
-            nw = len(self.wave)
-            Sigma = np.zeros([nw, nw])
-            #diag = np.diag_indices_from(Sigma)
-            Sigma[(np.arange(nw), np.arange(nw))] += self.sigma**2 + (jitter*self.flux)**2
-            Sigma[(locs, locs)] += amps**2
-        else:
-            raise ValueError
+        # make sure the flux vector exists and is of proper length
+        if np.all(self.flux == 1):
+            self.flux = np.ones_like(self.sigma)
+        assert len(self.flux) > np.max(locs)
+        assert len(self.flux) == len(self.sigma)
         
+        nw = len(self.sigma)
+        Sigma = np.zeros([nw, nw])
+        Sigma[(np.arange(nw), np.arange(nw))] += self.sigma**2 + (jitter*self.flux)**2
+        Sigma[(locs, locs)] += (amps*self.flux[locs])**2
+
         return Sigma

--- a/bsfh/likelihood.py
+++ b/bsfh/likelihood.py
@@ -105,6 +105,7 @@ class LikelihoodFunction(object):
         mask = obs.get('phot_mask', np.ones( len(obs['maggies']), dtype= bool))
         delta = (obs['maggies'] - phot_mu)[mask]
         if gp is not None:
+            gp.flux = obs['maggies'][mask]
             gp.compute(obs['filter_metric'][mask], obs['maggies_unc'][mask])
             return gp.lnlikelihood(delta)
         
@@ -120,7 +121,8 @@ class LikelihoodFunction(object):
 
     def lnpostfn(self, theta, model=None, obs=None,
                sps=None, gp=None, **extras):
-        """A specific implementation of a posterior probability function, as an example
+        """A specific implementation of a posterior probability
+        function, as an example.
         """
         if model is None:
             model = self.model

--- a/bsfh/likelihood.py
+++ b/bsfh/likelihood.py
@@ -8,7 +8,7 @@ class LikelihoodFunction(object):
         self.model = model
         self.lnspec = lnspec
         
-    def lnlike_spec(self, spec_mu, obs=None, gp=None):
+    def lnlike_spec(self, spec_mu, obs=None, gp=None, **extras):
         """Calculate the likelihood of the spectroscopic data given
         the spectroscopic model.  Allows for the use of a gaussian
         process covariance matrix for multiplicative residuals.
@@ -59,13 +59,12 @@ class LikelihoodFunction(object):
         
 
 
-    def lnlike_phot(self, phot_mu, obs=None, gp=None):
+    def lnlike_phot(self, phot_mu, obs=None, gp=None,
+                    phot_noise_fractional=True, **extras):
         """Calculate the likelihood of the photometric data given the
         spectroscopic model.  Allows for the use of a gaussian process
-        covariance matrix, though for *additive* residuals.  In
-        general, one would only want to mess with the diagonal in
-        linear space
-
+        covariance matrix.
+        
         :param phot_mu:
             The mean model sed, in linear flux units (i.e. maggies),
             including e.g. calibration and sky emission and nebular
@@ -79,18 +78,19 @@ class LikelihoodFunction(object):
                ``maggies``
               *``phot_mask`` optional boolean array of same length as
                ``maggies``
-              *``filter_metric`` if using a GP, the metric that is
-               used in the kernel generation, of same length as
-               ``maggies`` and typically giving the wavelengths or
-               some ordering.
-
+              *``filters`` optional list of sedpy.observate.Filter
+               objects, necessary if using fixed filter groups with
+               different gp amplitudes for each group.
            If not supplied then the obs dictionary given at
-           initialization will be used.  This should really all be in
-           kwargs.
+           initialization will be used.  
 
         :param gp: (optional)
             A Gaussian process object with the methods ``compute()`` and
             ``lnlikelihood()``.
+
+        :param fractional:
+            Treat the GP amplitudes as additional *fractional*
+            uncertainties, i.e., multiplicative uncertainties.
             
         :returns lnlikelhood:
             The natural logarithm of the likelihood of the data given
@@ -105,8 +105,11 @@ class LikelihoodFunction(object):
         mask = obs.get('phot_mask', np.ones( len(obs['maggies']), dtype= bool))
         delta = (obs['maggies'] - phot_mu)[mask]
         if gp is not None:
-            gp.flux = obs['maggies'][mask]
-            gp.compute(obs['filter_metric'][mask], obs['maggies_unc'][mask])
+            if phot_noise_fractional:
+                gp.flux = phot_mu[mask]
+            else:
+                gp.flux = 1
+            gp.compute(wave=1, sigma=obs['maggies_unc'][mask])
             return gp.lnlikelihood(delta)
         
         var = (obs['maggies_unc'][mask])**2

--- a/bsfh/model_setup.py
+++ b/bsfh/model_setup.py
@@ -46,7 +46,9 @@ def get_run_params(param_file=None, argv = None, **kwargs):
         rp = deepcopy(setup_module.run_params)
     elif ext == 'json':
         rp, mp = parameters.read_plist(param_file)
-    rp.update(kwargs)
+    if kwargs is not None:
+        kwargs.update(rp)
+        rp = kwargs
     if argv is not None:
         rp = parse_args(argv, argdict=rp)
     rp['param_file'] = param_file

--- a/bsfh/parameters.py
+++ b/bsfh/parameters.py
@@ -10,7 +10,7 @@ param_template = {'name':'', 'N':1, 'isfree': False,
 
 class ProspectrParams(object):
     """
-    :param mp:
+    :param config_list:
         A list of ``model parameters``.
     
     """

--- a/bsfh/priors.py
+++ b/bsfh/priors.py
@@ -62,7 +62,7 @@ def plotting_range(prior_args):
 class Prior(object):
     """
     Encapsulate the priors in an object.  On initialization each prior
-    should have a function name and optioanl parameters specifiyfy
+    should have a function name and optional parameters specifiyfy
     scale and location passed (e.g. min/max or mean/sigma).  When
     called, the argument should be a variable and it should return the
     prior probability of that value.  One should be able to sample
@@ -71,19 +71,27 @@ class Prior(object):
     plotting range and, if there are bounds, to return them.
     """
 
-    def __init__( kind, *args):
+    def __init__(self, kind, *args, **kwargs):
+        self._function = function[kind]
+        self.args = *args
+        self.kwargs = **kwargs
+        self._gradient = gradient[kind]
+        
+    def __call__(self, theta):
+        return self._function(theta, *self.args, **self.kwargs)
+    
+    def sample(self, nsample):
+        return self._sampler(nsample)
+    
+    def gradient(self, theta):
+        return self._gradient(theta, *self.args, **self.kwargs)
+    
+    def range(self):
         pass
-    def __call__(theta):
-        pass
-    def sample(nsample):
-        pass
-    def gradient(theta):
-        pass
-    def range():
-        pass
+    
     @property
-    def bounds():
+    def bounds(self):
         pass
 
-    def serialize():
+    def serialize(self):
         pass

--- a/bsfh/priors.py
+++ b/bsfh/priors.py
@@ -36,8 +36,16 @@ def lognormal(theta, log_mean=0.0, sigma=1.0, **extras):
         return ( np.log((2*np.pi)**(-0.5)/(theta*sigma)) -
                 (np.log(theta) - log_mean)**2/(2*sigma**2) )
     else:
-        return -np.infty
+        return -np.infty * np.ones(len(theta))
 
+def logarithmic(theta, mini=0.0, maxi=np.inf, **extras):
+    """A logarithmic (1/x) prior, with optional bounds.
+    """
+    lnp = -np.log(theta)
+    n = (theta < mini) | (theta > maxi)
+    lnp[n] = -np.infty
+    return lnp
+    
 def plotting_range(prior_args):
     if 'mini' in prior_args:
         return prior_args['mini'], prior_args['maxi']

--- a/bsfh/read_results.py
+++ b/bsfh/read_results.py
@@ -71,7 +71,7 @@ def model_comp(theta, model, sps, photflag=0, gp=None):
         
     return sed, cal, delta, mask, wave
 
-def param_evol(sample_results, outname=None, showpars=None, start=0):
+def param_evol(sample_results, outname=None, showpars=None, start=0, **plot_kwargs):
     """
     Plot the evolution of each parameter value with iteration #, for
     each chain.
@@ -109,7 +109,7 @@ def param_evol(sample_results, outname=None, showpars=None, start=0):
     for i in range(ndim):
         ax = axes.flatten()[i]
         for j in range(nwalk):
-            ax.plot(chain[j,:,i])
+            ax.plot(chain[j,:,i], **plot_kwargs)
         ax.set_title(parnames[i])
     if outname is not None:
         fig.savefig('{0}.x_vs_step.png'.format(outname))

--- a/bsfh/sedmodel.py
+++ b/bsfh/sedmodel.py
@@ -184,7 +184,7 @@ class CSPModel(ProspectrParams):
         # !but python-FSPS does not!
         if sps.params['zred'] == 0:
             # Use 10pc for the luminosity distance (or a number
-            # provided in the dist key)
+            # provided in the dist key in units of Mpc)
             dfactor = (self.params.get('dist', 1e-5) * 1e5)**2
         else:
             dfactor = ((cosmo.luminosity_distance(sps.params['zred']).value *
@@ -249,16 +249,67 @@ class CSPModel(ProspectrParams):
     def phot_calibration(self, **extras):
         return 1.0
 
-    def phot_gp_params(self, **extras):
-        pars = ['phot_jitter', 'gp_amps', 'gp_locs']
-        defaults = [0.0, [0.0], [0]]
-        vals = [self.params.get(p, d) for p, d in zip(pars, defaults)]
-        return  tuple(vals)
+    def phot_gp_params(self, obs=None, outlier=False, theta=None,
+                       **extras):
+        """Return the parameters for generating the covariance matrix
+        used by the photometric gaussian process in a way
+        understandable for the GP objects.  This method looks for the
+        ``phot_jitter``, ``gp_phot_amps`` and ``gp_phot_locs`` keys in
+        the parameter dictionary
 
+        :param obs:
+            obs data dictionary.  Must have a ``filters`` key.
+            
+        :param outlier:
+            Switch to interpret the gp parameters in terms of outlier
+            modeling.  In this case ``gp_phot_locs`` is an array of
+            indices into the (masked) maggies array, and
+            ``gp_phot_amps`` is an array of GP amplitudes
+            corresponding to these indices.
+
+            Otherwise, ``gp_phot_locs`` is a fixed array of filter
+            name lists, and ``gp_phot_amps`` is an array of the same
+            length giving the GP amplitudes associated with each list
+
+        :returns s:
+            The jitter (scalar)
+
+        :returns amps:
+            The GP amplitudes, ndarray.
+
+        :returns locs:
+            Indices into the obs['maggies'][obs['phot_mask']] array
+            corresponding elementwise to the returned ``amps`` array
+        """
+
+        if theta is not None:
+            self.set_parameters(theta)
+            
+        mask = obs.get('phot_mask', np.ones( len(obs['filters']), dtype= bool))
+        pars = ['phot_jitter', 'gp_phot_amps', 'gp_phot_locs']
+        defaults = [0.0, [0.0], [0]]
+        s, amps, locs = [self.params.get(p, d) for p, d in zip(pars, defaults)]
+        no_locs = 'gp_phot_locs' not in self.params
+        #outlier modeling allows the locations to float. locs here are indices
+        if outlier or no_locs:
+            locs = np.clip(locs, 0, mask.sum() - 1)
+            return s, np.atleast_1d(amps), np.atleast_1d(locs)
         
+        # Here we add linked amplitudes based on filter names.  locs
+        # here is an array of lists
+        ll, aa = [], []
+        if type(obs['filters'][0]) is str:
+            fnames = [f for i,f in enumerate(obs['filters']) if mask[i]]
+        else:
+            fnames = [f.name for i,f in enumerate(obs['filters']) if mask[i]]
+        for i, a in enumerate(amps):
+            filts = locs[i]
+            ll += [fnames.index(f) for f in filts if f in fnames]
+            aa += len(filts) * [a] 
+        return  s, np.atleast_1d(aa), np.atleast_1d(ll)
+
     def sky(self):
         return 0.
-
 
 def gauss(x, mu, A, sigma):
     """

--- a/bsfh/sedmodel.py
+++ b/bsfh/sedmodel.py
@@ -120,8 +120,10 @@ class SedModel(ProspectrParams):
             return 1.0
 
     def spec_gp_params(self, **extras):
-        return  (self.params['gp_jitter'], self.params['gp_amplitude'],
-                 self.params['gp_length'])
+        pars = ['gp_jitter', 'gp_amplitude', 'gp_length']
+        defaults = [0.0, 0.0, 1.0]
+        vals = [self.params.get(p, d) for p, d in zip(pars, defaults)]
+        return  tuple(vals)
     
 class CSPModel(ProspectrParams):
     """
@@ -181,7 +183,9 @@ class CSPModel(ProspectrParams):
         #modern FSPS does the distance modulus for us in get_mags,
         # !but python-FSPS does not!
         if sps.params['zred'] == 0:
-            dfactor = 1
+            # Use 10pc for the luminosity distance (or a number
+            # provided in the dist key)
+            dfactor = (self.params.get('dist', 1e-5) * 1e5)**2
         else:
             dfactor = ((cosmo.luminosity_distance(sps.params['zred']).value *
                         1e5)**2 / (1+sps.params['zred']))
@@ -244,7 +248,14 @@ class CSPModel(ProspectrParams):
 
     def phot_calibration(self, **extras):
         return 1.0
-    
+
+    def phot_gp_params(self, **extras):
+        pars = ['phot_jitter', 'gp_amps', 'gp_locs']
+        defaults = [0.0, [0.0], [0]]
+        vals = [self.params.get(p, d) for p, d in zip(pars, defaults)]
+        return  tuple(vals)
+
+        
     def sky(self):
         return 0.
 


### PR DESCRIPTION
This pull request implements more flexible photometric noise modeling by modifying the diagonal of a noise covariance matrix.  The associated model parameters are ``phot_jitter``, ``gp_phot_amps`` and ``gp_phot_locs``.  If ``gp_phot_locs`` is present and ``outlier==False``, then each element of `gp_phot_locs` is treated as an iterable giving a group of filters to which extra noise (given by the  `gp_phot_amps` is to be added.  If ``outlier==True`` then the gp_phot_locs are treated as indices to the SED array, and can be varying parameters of the model.