### PR TITLE
Fractional spec gp

### DIFF
--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -18,6 +18,8 @@ class GaussianProcess(object):
             If supplied, the additional noise given by the jitter can
             be specified as a fraction of the flux
         """
+        self.reset()
+        
         if kernel is None:
             npar = self.kernel_properties[0]
             self.kernel = np.zeros(npar)

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -131,7 +131,7 @@ class GaussianProcess(object):
         
         return lnL
               
-    def predict(self, residual, wave=None):
+    def predict(self, residual, wave=None, sigma=None, flux=None):
         """
         For a given residual vector, give the GP mean prediction at
         each wavelength and the covariance matrix.  This is currently broken.
@@ -143,7 +143,7 @@ class GaussianProcess(object):
             Wavelengths at which mean and variance estimates are desired.
             Defaults to the input wavelengths.
         """
-        
+        self.update_data(wave, sigma, flux)
         
         Sigma_cross = self.construct_covariance(inwave=wave, cross=True)
         Sigma_star = self.construct_covariance(inwave=wave, cross=False)

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy.linalg import cho_factor, cho_solve
-from scipy import sparse
 
 class GaussianProcess(object):
 
@@ -192,8 +191,7 @@ class ExpSquared(GaussianProcess):
             Sigma = asq * np.exp(-(self._wave[:,None] - self._wave[None,:])**2/(2*lsq))
             dinds = np.diag_indices_from(Sigma)
             if np.any(self._flux != 1):
-                scale = sparse.diags(self._flux, 0)
-                Sigma = scale.T.dot(scale.dot(Sigma).T).T
+                Sigma = self._flux[:,None] * Sigma * self._flux[None, :]
             Sigma[dinds] += (self._sigma**2 + s**2)
             return Sigma
         elif cross:

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -26,65 +26,92 @@ class GaussianProcess(object):
         #_params stores the values of kernel parameters used to
         #construct and compute the factorized covariance matrix that
         #is stored in factorized_Sigma
+        self.params_clean = False
         self._params = None
-        self.wave = wave
-        self.sigma = sigma
-        self.flux = flux
-        self.kernel_clean = False
+        self.data_clean = False
+        self.update_data(wave, sigma, flux)
+        
         
     def reset(self):
+        """Blank out the cached values.
+        """
         self.factorized_Sigma = None
-        self.wave = None
-        self.sigma = None
+        self._wave = None
+        self._sigma = None
+        self._flux = 1
         self._params = None
         self.kernel = None
+        self.data_clean = False
+        self.params_clean = False
         
-    def set_params(self):
+    def update_params(self):
+        """Update the internel kernel parameters using values stored
+        in the ``kernel`` property, which may be changed explicitly
+        from the outside.  If the contents of ``kernel`` are different
+        than the chached parameters, set the params_clean flag to
+        False.
+        """
         params = self.kernel_to_params(self.kernel)
         self.params_clean = np.array_equal(params, self._params)
         self._params = params
         
-              
-    def compute(self, wave=None, sigma=None, check_finite=False,
-                force=False, **extras):
+    def update_data(self, wave, sigma, flux):
+        """Update the data used to generate the covariance matrix.  If
+        the data has changed, set the data_clean property to False.
+        If supplied data are None, use cached values.  Otherwise cache
+        the supplied values.
+        """
+        data_clean = True
+        if wave is not None:
+            data_clean = data_clean & np.array_equal(wave, self._wave)
+            self._wave = wave
+        if sigma is not None:
+            data_clean = data_clean & np.array_equal(sigma, self._sigma)
+            self._sigma = sigma  
+        if flux is not None:
+            data_clean = data_clean & np.array_equal(flux, self._flux)
+            self._flux = flux
+        self.data_clean = self.data_clean & data_clean
+            
+    def compute(self, wave=None, sigma=None, flux=None,
+                check_finite=False, force=False, **extras):
         """Construct the covariance matrix, factorize it, and store
         the factorized matrix.  The factorization is only performed if
         the kernel parameters have chenged or the observational data
         (wave and sigma) have changed.
         
         :param wave: optional
-            independent variable.
+            independent vari able.
             
         :param sigma:
             uncertainties on the dependent variable at the locations
             of the independent variable
             
+        :param flux:
+            A scaling vector (or scalar) for the uncertainties.  A
+            value of ``1`` does not scale the uncertainties at all
+            
         :param force: optional
             If true, force a recomputation even if the kernel and the
             data are the same as for the stored factorization.
         """
-        if wave is None:
-            wave = self.wave
-        if sigma is None:
-            sigma = self.sigma
-        data_clean = (np.all(wave == self.wave) &
-                     np.all(sigma == self.sigma))
-        #params = self.kernel_to_params(self.kernel)
-        self.set_params()
-
-        if self.params_clean and data_clean and (not force):
+        self.update_params()
+        self.update_data(wave, sigma, flux)
+        
+        if self.params_clean and self.data_clean and (not force):
+            # Nothing changed
             return
         
         else:
-            self.wave = wave
-            self.sigma = sigma
-            
+            # Something changed or we're forcing regeneration
             Sigma = self.construct_covariance()
             self.factorized_Sigma  = cho_factor(Sigma, overwrite_a=True,
                                                 check_finite=check_finite)
             self.log_det = 2 * np.sum( np.log(np.diag(self.factorized_Sigma[0])))
             assert np.isfinite(self.log_det)
-
+            self.data_clean = True
+            self.params_clean = True
+            
     def lnlikelihood(self, residual, check_finite=False, **extras):
         """
         Compute the ln of the likelihood, using the current factorized
@@ -93,19 +120,19 @@ class GaussianProcess(object):
         :param residual: ndarray, shape (nwave,)
             Vector of residuals (y_data - mean_model).
         """
-        assert ( len(residual) == len(self.sigma))
+        assert ( len(residual) == len(self._sigma) )
         self.compute()
         first_term = np.dot(residual,
                             cho_solve(self.factorized_Sigma,
                                       residual, check_finite = check_finite))
-        lnL=  -0.5 * (first_term + self.log_det)
+        lnL = -0.5 * (first_term + self.log_det)
         
         return lnL
               
     def predict(self, residual, wave=None):
         """
         For a given residual vector, give the GP mean prediction at
-        each wavelength and the covariance matrix.
+        each wavelength and the covariance matrix.  This is currently broken.
 
         :param residual:
             Vector of residuals (y_data - mean_model).
@@ -157,13 +184,17 @@ class ExpSquared(GaussianProcess):
         """Construct an exponential squared covariance matrix
         """
         s, asq, lsq = self._params
-        
+            
         if inwave is None:
-            Sigma = asq * np.exp(-(self.wave[:,None] - self.wave[None,:])**2/(2*lsq))
-            Sigma[np.diag_indices_from(Sigma)] += (self.sigma**2 + s**2)
+            Sigma = asq * np.exp(-(self._wave[:,None] - self._wave[None,:])**2/(2*lsq))
+            dinds = np.diag_indices_from(Sigma)
+            if np.any(self._flux != 1):
+                scale = np.diag(self._flux)
+                Sigma = np.dot(scale, Sigma).dot(scale)
+            Sigma[dinds] += (self._sigma**2 + s**2)
             return Sigma
         elif cross:
-            Sigma = asq * np.exp(-(inwave[:,None] - self.wave[None,:])**2/(2*lsq))
+            Sigma = asq * np.exp(-(inwave[:,None] - self._wave[None,:])**2/(2*lsq))
             return Sigma
         else:
             Sigma = asq * np.exp(-(inwave[:,None] - inwave[None,:])**2/(2*lsq))
@@ -193,14 +224,17 @@ class PhotOutlier(GaussianProcess):
         #round to the nearest index
         locs = locs.astype(int)
         # make sure the flux vector exists and is of proper length
-        if np.all(self.flux == 1):
-            self.flux = np.ones_like(self.sigma)
-        assert len(self.flux) > np.max(locs)
-        assert len(self.flux) == len(self.sigma)
+        nw = len(self._sigma)
+        if np.all(self._flux == 1):
+            flux = np.ones(nw)
+        else:
+            flux = self._flux
+        assert len(flux) > np.max(locs)
+        assert len(flux) == nw
         
-        nw = len(self.sigma)
+        
         Sigma = np.zeros([nw, nw])
-        Sigma[(np.arange(nw), np.arange(nw))] += self.sigma**2 + (jitter*self.flux)**2
-        Sigma[(locs, locs)] += (amps*self.flux[locs])**2
+        Sigma[(np.arange(nw), np.arange(nw))] += self._sigma**2 + (jitter*flux)**2
+        Sigma[(locs, locs)] += (amps*flux[locs])**2
 
         return Sigma

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -43,7 +43,7 @@ class GaussianProcess(object):
         self._sigma = None
         self._flux = 1
         self._params = None
-        self.kernel = None
+        self.kernel = np.zeros(self.kernel_properties[0])
         self.data_clean = False
         self.params_clean = False
         

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -235,7 +235,6 @@ class PhotOutlier(GaussianProcess):
         assert len(flux) > np.max(locs)
         assert len(flux) == nw
         
-        
         Sigma = np.zeros([nw, nw])
         Sigma[(np.arange(nw), np.arange(nw))] += self._sigma**2 + (jitter*flux)**2
         Sigma[(locs, locs)] += (amps*flux[locs])**2

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.linalg import cho_factor, cho_solve
+from scipy import sparse
 
 class GaussianProcess(object):
 
@@ -191,8 +192,8 @@ class ExpSquared(GaussianProcess):
             Sigma = asq * np.exp(-(self._wave[:,None] - self._wave[None,:])**2/(2*lsq))
             dinds = np.diag_indices_from(Sigma)
             if np.any(self._flux != 1):
-                scale = np.diag(self._flux)
-                Sigma = np.dot(scale, Sigma).dot(scale)
+                scale = sparse.diags(self._flux, 0)
+                Sigma = scale.T.dot(scale.dot(Sigma).T).T
             Sigma[dinds] += (self._sigma**2 + s**2)
             return Sigma
         elif cross:

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -122,19 +122,21 @@ class GaussianProcess(object):
         :param residual: ndarray, shape (nwave,)
             Vector of residuals (y_data - mean_model).
         """
-        assert ( len(residual) == len(self._sigma) )
+        n = len(residual)
+        assert ( n == len(self._sigma) )
         self.compute()
         first_term = np.dot(residual,
                             cho_solve(self.factorized_Sigma,
                                       residual, check_finite = check_finite))
-        lnL = -0.5 * (first_term + self.log_det)
+        lnL = -0.5 * (first_term + self.log_det + n * np.log(2.*np.pi))
         
         return lnL
               
     def predict(self, residual, wave=None, sigma=None, flux=None):
         """
         For a given residual vector, give the GP mean prediction at
-        each wavelength and the covariance matrix.  This is currently broken.
+        each wavelength and the covariance matrix.  This is currently
+        broken if wave is not None.
 
         :param residual:
             Vector of residuals (y_data - mean_model).
@@ -162,7 +164,7 @@ class GaussianProcess(object):
     
     def kernel_to_params(self, kernel):
         """A method that takes an ndarray and returns a blob of kernel
-        parameters.  mostly usied for a sort of documentation, but
+        parameters.  mostly used for a sort of documentation, but
         also for grouping parameters
         """
         raise NotImplementedError

--- a/bsfh/gp.py
+++ b/bsfh/gp.py
@@ -30,6 +30,7 @@ class GaussianProcess(object):
         self.wave = wave
         self.sigma = sigma
         self.flux = flux
+        self.kernel_clean = False
         
     def reset(self):
         self.factorized_Sigma = None
@@ -38,11 +39,11 @@ class GaussianProcess(object):
         self._params = None
         self.kernel = None
         
-    @property
-    def kernel_same(self):
+    def set_params(self):
         params = self.kernel_to_params(self.kernel)
-        ksame = np.array_equal(params, self._params)
-        return ksame, params
+        self.params_clean = np.array_equal(params, self._params)
+        self._params = params
+        
               
     def compute(self, wave=None, sigma=None, check_finite=False,
                 force=False, **extras):
@@ -66,16 +67,15 @@ class GaussianProcess(object):
             wave = self.wave
         if sigma is None:
             sigma = self.sigma
-        data_same = (np.all(wave == self.wave) &
+        data_clean = (np.all(wave == self.wave) &
                      np.all(sigma == self.sigma))
         #params = self.kernel_to_params(self.kernel)
-        ksame, params = self.kernel_same
+        self.set_params()
 
-        if ksame and data_same and (not force):
+        if self.params_clean and data_clean and (not force):
             return
         
         else:
-            self._params = params
             self.wave = wave
             self.sigma = sigma
             

--- a/bsfh/likelihood.py
+++ b/bsfh/likelihood.py
@@ -62,7 +62,7 @@ class LikelihoodFunction(object):
                 gp.compute(obs['wavelength'][mask], obs['unc'][mask], flux=flux)
                 return gp.lnlikelihood(delta)
             except(LinAlgError):
-                return -np.inf
+                return np.nan_to_num(-np.inf)
             
         var = obs['unc'][mask]**2
         lnp = -0.5*( (delta**2/var).sum() +

--- a/bsfh/likelihood.py
+++ b/bsfh/likelihood.py
@@ -58,9 +58,12 @@ class LikelihoodFunction(object):
                 flux = spec_mu[mask]
             else:
                 flux = 1
-            gp.compute(obs['wavelength'][mask], obs['unc'][mask], flux=flux)
-            return gp.lnlikelihood(delta)
-        
+            try:
+                gp.compute(obs['wavelength'][mask], obs['unc'][mask], flux=flux)
+                return gp.lnlikelihood(delta)
+            except(LinAlgError):
+                return -np.inf
+            
         var = obs['unc'][mask]**2
         lnp = -0.5*( (delta**2/var).sum() +
                      np.log(2*np.pi*var).sum() )

--- a/bsfh/likelihood.py
+++ b/bsfh/likelihood.py
@@ -8,7 +8,8 @@ class LikelihoodFunction(object):
         self.model = model
         self.lnspec = lnspec
         
-    def lnlike_spec(self, spec_mu, obs=None, gp=None, **extras):
+    def lnlike_spec(self, spec_mu, obs=None, gp=None,
+                    spec_noise_fractional=False, **extras):
         """Calculate the likelihood of the spectroscopic data given
         the spectroscopic model.  Allows for the use of a gaussian
         process covariance matrix for multiplicative residuals.
@@ -35,7 +36,11 @@ class LikelihoodFunction(object):
             A Gaussian process object with the methods `compute` and
             `lnlikelihood`.  If gp is supplied, the `wavelength` entry
             in the obs dictionary must exist
-            
+
+        :param spec_noise_fractional: (optional)
+            If true then the amplitude of the GP is taken to be a
+            fraction of the model flux.
+             
         :returns lnlikelhood:
             The natural logarithm of the likelihood of the data given
             the mean model spectrum.
@@ -49,7 +54,11 @@ class LikelihoodFunction(object):
         mask = obs.get('mask', np.ones( len(obs['spectrum']), dtype= bool))
         delta = (obs['spectrum'] - spec_mu)[mask]
         if gp is not None:
-            gp.compute(obs['wavelength'][mask], obs['unc'][mask])
+            if spec_noise_fractional:
+                flux = spec_mu[mask]
+            else:
+                flux = 1
+            gp.compute(obs['wavelength'][mask], obs['unc'][mask], flux=flux)
             return gp.lnlikelihood(delta)
         
         var = obs['unc'][mask]**2
@@ -106,10 +115,10 @@ class LikelihoodFunction(object):
         delta = (obs['maggies'] - phot_mu)[mask]
         if gp is not None:
             if phot_noise_fractional:
-                gp.flux = phot_mu[mask]
+                flux = phot_mu[mask]
             else:
-                gp.flux = 1
-            gp.compute(wave=1, sigma=obs['maggies_unc'][mask])
+                flux = 1
+            gp.compute(wave=1, sigma=obs['maggies_unc'][mask], flux=flux)
             return gp.lnlikelihood(delta)
         
         var = (obs['maggies_unc'][mask])**2

--- a/bsfh/likelihood.py
+++ b/bsfh/likelihood.py
@@ -1,5 +1,6 @@
 import time, sys, os
 import numpy as np
+from scipy.linalg import LinAlgError
 
 class LikelihoodFunction(object):
     

--- a/bsfh/read_results.py
+++ b/bsfh/read_results.py
@@ -47,7 +47,8 @@ def model_comp(theta, model, obs, sps, photflag=0, gp=None):
     Generate and return various components of the total model for a
     given set of parameters
     """
-    obs, _, _ = obsdict(obs, photflag=photflag)
+    logarithmic = obs.get('logify_spectrum')
+    obs, _, _ = obsdict(obs, photflag=photflag)    
     mask = obs['mask']
     mu = model.mean_model(theta, obs, sps=sps)[photflag][mask]
     sed = model.sed(theta, obs, sps=sps)[photflag][mask]
@@ -62,7 +63,11 @@ def model_comp(theta, model, obs, sps, photflag=0, gp=None):
             gp.kernel[:] = np.log(np.array([s[0],a[0]**2,l[0]**2]))
             gp.compute(obs['wavelength'][mask], obs['unc'][mask])
             spec = obs['spectrum'][mask]
-            delta = gp.predict(spec - mu, obs['wavelength'][mask])
+            if logarithmic:
+                delta = gp.predict(spec - mu, wave)
+            else:
+                gp._wave = wave #Hack till I fix gp predict method
+                delta = gp.predict(spec - mu, wave=None, flux=mu)
             if len(delta) ==2:
                 delta = delta[0]
         except(AttributeError, KeyError):

--- a/bsfh/read_results.py
+++ b/bsfh/read_results.py
@@ -61,12 +61,13 @@ def model_comp(theta, model, obs, sps, photflag=0, gp=None):
         try:
             s, a, l = model.spec_gp_params()
             gp.kernel[:] = np.log(np.array([s[0],a[0]**2,l[0]**2]))
-            gp.compute(obs['wavelength'][mask], obs['unc'][mask])
             spec = obs['spectrum'][mask]
             if logarithmic:
+                gp.compute(wave, obs['unc'][mask])
                 delta = gp.predict(spec - mu, wave)
             else:
-                gp._wave = wave #Hack till I fix gp predict method
+                gp.compute(wave, obs['unc'][mask], flux=mu)
+                #gp._wave = wave #Hack till I fix gp predict method
                 delta = gp.predict(spec - mu, wave=None, flux=mu)
             if len(delta) ==2:
                 delta = delta[0]

--- a/bsfh/read_results.py
+++ b/bsfh/read_results.py
@@ -71,7 +71,7 @@ def model_comp(theta, model, obs, sps, photflag=0, gp=None):
                 delta = gp.predict(spec - mu, wave=None, flux=mu)
             if len(delta) ==2:
                 delta = delta[0]
-        except(AttributeError, KeyError):
+        except(TypeError, AttributeError, KeyError):
             delta = 0
     else:
         mask = np.ones(len(obs['wavelength']), dtype= bool)

--- a/bsfh/sedmodel.py
+++ b/bsfh/sedmodel.py
@@ -125,11 +125,20 @@ class SedModel(ProspectrParams):
         else:
             return 1.0
 
-    def spec_gp_params(self, **extras):
+    def spec_gp_params(self, theta=None, **extras):
+        if theta is not None:
+            self.set_parameters(theta)
         pars = ['gp_jitter', 'gp_amplitude', 'gp_length']
         defaults = [0.0, 0.0, 1.0]
         vals = [self.params.get(p, d) for p, d in zip(pars, defaults)]
         return  tuple(vals)
+    
+    def phot_gp_params(self, theta=None, **extras):
+        if theta is not None:
+            self.set_parameters(theta)
+        s = self.params.get('phot_jitter', 0.0)
+        return s, [0.0], [0]
+
     
 class CSPModel(ProspectrParams):
     """

--- a/bsfh/sedmodel.py
+++ b/bsfh/sedmodel.py
@@ -43,7 +43,7 @@ class SedModel(ProspectrParams):
         """
         s, p, x = self.sed(theta, obs, sps=sps, **extras)
         if obs.get('logify_spectrum', True):
-            s = np.log(s) + self.spec_calibration(obs=obs, **extras)
+            s = np.log(s) + np.log(self.spec_calibration(obs=obs, **extras))
         else:
             s *= self.spec_calibration(obs=obs, **extras)
         return s, p, x
@@ -121,7 +121,7 @@ class SedModel(ProspectrParams):
             if self.params.get('cal_type', 'exp_poly') is 'poly':
                 return (1.0 + poly) * self.params['spec_norm']
             else:
-                return self.params['spec_norm'] + poly
+                return np.exp(self.params['spec_norm'] + poly)
         else:
             return 1.0
 


### PR DESCRIPTION
This introduces some hacks to make a SquaredExponential GP work with amplitudes defined as a fraction of the model.  This is accomplished by multiplying the covariance matrix by the model.