### PR TITLE
return burn-in positions and probabilities

### DIFF
--- a/bsfh/fitterutils.py
+++ b/bsfh/fitterutils.py
@@ -60,7 +60,7 @@ def run_emcee_sampler(lnprobf, initial_center, model,
     if verbose:
         print('done production')
 
-    return esampler, epos, eprob
+    return esampler, initial_center, initial_prob
 
 
 def reinitialize_ball(initial_center, pos, nwalkers, model,


### PR DESCRIPTION
I think this was a typo-- we wanted to return the position + probability at the end of the burn-in phase, not the final walker positions and probabilities, right?