### PR TITLE
Fft smoothing

### DIFF
--- a/bsfh/smoothing.py
+++ b/bsfh/smoothing.py
@@ -91,7 +91,7 @@ def smoothspec(wave, spec, resolution, outwave=None,
         width = 100
 
     # Mask the input spectrum depending on outwave or the wave_smooth kwargs
-    mask = mask_wave(wave, R=width, outwave=outwave, linear=linear,
+    mask = mask_wave(wave, width=width, outwave=outwave, linear=linear,
                      wlo=min_wave_smooth, whi=max_wave_smooth, **kwargs)
     w = wave[mask]
     s = spec[mask]
@@ -183,14 +183,13 @@ def smooth_vel_fft(wavelength, spectrum, outwave, sigma_out, inres=0.0,
         The velocity resolution of the input spectrum (km/s), dispersion *not*
         FWHM.
     """
-
-    # make lngth of spectrum a power of 2 by resampling
-    wave, spec = resample_wave(wavelength, spectrum)
-
     # The kernel width for the convolution.
     sigma = np.sqrt(sigma_out**2 - inres**2)
     if sigma <= 0:
-        return np.interp(wave, outwave, flux)
+        return np.interp(outwave, wavelength, spectrum)
+
+    # make lngth of spectrum a power of 2 by resampling
+    wave, spec = resample_wave(wavelength, spectrum)
 
     # get grid resolution (*not* the resolution of the input spectrum) and make
     # sure it's nearly constant.  Should be by design (see resample_wave)
@@ -246,7 +245,7 @@ def smooth_wave(wave, spec, outwave, sigma, nsigma=10, inres=0, in_vel=False,
     """
     # sigma_eff is in angstroms
     if inres <= 0:
-        sigma_eff_sq = sigma**
+        sigma_eff_sq = sigma**2
     elif in_vel:
         # Make an approximate correction for the intrinsic wavelength
         # dependent dispersion.  This sort of maybe works.
@@ -395,7 +394,7 @@ def mask_wave(wavelength, width=1, wlo=0, whi=np.inf, outwave=None,
     if outwave is not None:
         wlim = np.array([outwave.min(), outwave.max()])
     else:
-        wlim = np.array([wlo, whi])
+        wlim = np.squeeze(np.array([wlo, whi]))
     # Pad by nsigma * sigma_wave
     if linear:
         wlim += nsigma_pad * width * np.array([-1, 1])
@@ -422,7 +421,7 @@ def resample_wave(wavelength, spectrum, linear=False):
         lnlam = np.linspace(np.log(wmin), np.log(wmax), nnew)
         w = np.exp(lnlam)
     # Make sure the resolution really is nearly constant
-    assert Rgrid.max() / Rgrid.min() < 1.05
+    #assert Rgrid.max() / Rgrid.min() < 1.05
     s = np.interp(w, wavelength, spectrum)
     return w, s
 

--- a/bsfh/smoothing.py
+++ b/bsfh/smoothing.py
@@ -9,8 +9,10 @@
 
 import numpy as np
 
+ckms = 2.998e5
+
 def smoothspec(wave, spec, sigma, outwave=None, smoothtype='vel',
-               min_wave_smooth=None, max_wave_smooth=None,
+               min_wave_smooth=None, max_wave_smooth=None, fast=False,
                **kwargs):
     """
     :param wave:
@@ -24,10 +26,10 @@ def smoothspec(wave, spec, sigma, outwave=None, smoothtype='vel',
         The smoothing parameter.  Units depend on ``smoothtype``
         
     :param outwave:
-        The output wavelength vector.  If None then the input
-        wavelength vector will be assumed.  If min_wave_smooth or
-        max_wave_smooth are also specified, then the output spectrum
-        may have differnt dimensions than spec or inwave.
+        The output wavelength vector.  If None then the input wavelength vector
+        will be assumed, though if min_wave_smooth or max_wave_smooth are also
+        specified, then the output spectrum may have different length than spec
+        or wave
 
     :param smoothtype:
         The type of smoothing to do.  One of
@@ -43,14 +45,14 @@ def smoothspec(wave, spec, sigma, outwave=None, smoothtype='vel',
           will be passed to the `lsf` function.
           
     :param min_wave_smooth:
-        The minimum wavelength of the input vector to consider when
-        smoothing the spectrum.  If None then it is determined from
-        the minimum of the output wavelength vector, minus 50.0.
+        The minimum wavelength of the input vector to consider when smoothing
+        the spectrum.  If None then it is determined from the minimum of the
+        output wavelength vector, minus 50.0.
 
     :param max_wave_smooth:
-        The maximum wavelength of the input vector to consider when
-        smoothing the spectrum.  If None then it is determined from
-        the minimum of the output wavelength vector, plus 50.0
+        The maximum wavelength of the input vector to consider when smoothing
+        the spectrum.  If None then it is determined from the minimum of the
+        output wavelength vector, plus 50.0
     """
     if outwave is None:
         outwave = wave
@@ -67,9 +69,9 @@ def smoothspec(wave, spec, sigma, outwave=None, smoothtype='vel',
     if smoothtype == 'vel':
         return smooth_vel(w, s, outwave, sigma, **kwargs)
     elif smoothtype == 'R':
-        sigma_vel = 2.998e5 / sigma
+        sigma_vel = ckms / sigma
         try:
-            kwargs['inres'] =  2.998e5 / kwargs['inres']
+            kwargs['inres'] =  ckms / kwargs['inres']
         except(KeyError):
             pass
         return smooth_vel(w, s, outwave, sigma_vel, **kwargs)
@@ -81,23 +83,31 @@ def smoothspec(wave, spec, sigma, outwave=None, smoothtype='vel',
 
 def smooth_vel(wave, spec, outwave, sigma, nsigma=10,
                 inres=0, **extras):
-    """Smooth a spectrum in velocity space.  This is insanely slow,
-    but general and correct.
+    """Smooth a spectrum in velocity space.  This is insanely slow, but general
+    and correct.
+
+    :param wave:
+        Wavelength vector of the input spectrum.
+
+    :param spec:
+        Flux vector of the input spectrum.
+
+    :param outwave:
+        Desired output wavelength vector.
 
     :param sigma:
         Desired velocity resolution (km/s), *not* FWHM.
 
     :param nsigma:
-        Number of sigma away from the output wavelength to consider in
-        the integral.  If less than zero, all wavelengths are used.
-        Setting this to some positive number decreses the scaling
-        constant in the O(N_out * N_in) algorithm used here.
+        Number of sigma away from the output wavelength to consider in the
+        integral.  If less than zero, all wavelengths are used.  Setting this
+        to some positive number decreses the scaling constant in the O(N_out *
+        N_in) algorithm used here.
 
     :param inres:
-        The velocity resolution of the input spectrum (km/s), *not*
-        FWHM.
+        The velocity resolution of the input spectrum (km/s), *not* FWHM.
     """
-    sigma_eff = np.sqrt(sigma**2 - inres**2)/2.998e5
+    sigma_eff = np.sqrt(sigma**2 - inres**2) / ckms
     if sigma_eff <= 0.0:
         return np.interp(wave, outwave, flux)
 
@@ -117,14 +127,73 @@ def smooth_vel(wave, spec, outwave, sigma, nsigma=10,
     return flux
 
 
+def smooth_vel_fft(wavelength, spectrum, outwave, sigma_out,
+                   sigma_in=0.0, **extras):
+    """Smooth a spectrum in wavelength space, using FFTs. This is fast, but makes
+    some assumptions about the form of the input spectrum and can have some
+    issues at the ends of the spectrum depending on how it is padded.
+
+    :param wavelength:
+        Wavelength vector of the input spectrum. An assertion error will result
+        if this is not a regular grid in wavelength.
+
+    :param spectrum:
+        Flux vector of the input spectrum.
+
+    :param outwave:
+        Desired output wavelength vector.
+
+    :param sigma_out:
+        Desired velocity resolution (km/s), *not* FWHM.
+
+    :param sigma_in:
+        The velocity resolution of the input spectrum (km/s), dispersion *not*
+        FWHM.
+    """
+    
+    # make lngth of spectrum a power of 2 by resampling
+    wave, spec = resample_wave(wavelength[mask], spectrum[mask])
+
+    # The kernel width for the convolution.
+    #sigma_out, sigma_in = ckms / Rout, ckms / Rin
+    sigma = np.sqrt(sigma_out**2 - sigma_in**2)
+    if sigma <= 0:
+        return np.interp(wave, outwave, flux)
+    
+    # get grid resolution (*not* the resolution of the input spectrum) and make
+    # sure it's nearly constant.  Should be by design (see resample_wave)
+    invRgrid =  np.diff(np.log(wave))
+    assert invRgrid.max() / invRgrid.min() < 1.05
+    dv = ckms * np.median(invRgrid)
+
+    # Do the convolution
+    spec_conv = smooth_fft(dv, spec, sigma)
+    # interpolate onto output grid
+    if outwave is not None:
+        spec_conv = np.interp(outwave, wave, spec_conv)
+
+    return spec_conv
+
+
 def smooth_wave(wave, spec, outwave, sigma, nsigma=10, 
                 input_res=0, in_vel=False, **extras):
-    """Smooth a spectrum in wavelength space.  This is insanely slow,
-    but general and correct (except for the treatment of the input
-    resolution if it is velocity)
+    """Smooth a spectrum in wavelength space.  This is insanely slow, but
+    general and correct (except for the treatment of the input resolution if it
+    is velocity)
+
+    :param wave:
+        Wavelength vector of the input spectrum.
+
+    :param spec:
+        Flux vector of the input spectrum.
+
+    :param outwave:
+        Desired output wavelength vector.
 
     :param sigma:
-        Desired resolution (*not* FWHM) in wavelength units.
+        Desired resolution (*not* FWHM) in wavelength units.  This can be a
+        vector of same length as ``wave``, in which case a wavelength dependent
+        broiadeining is calculated
 
     :param input_res:
         Resolution of the input, in either wavelength units or
@@ -135,10 +204,13 @@ def smooth_wave(wave, spec, outwave, sigma, nsigma=10,
         space, and ``inres`` is in dlambda/lambda.
 
     :param nsigma: (default=10)
-        Number of sigma away from the output wavelength to consider in
-        the integral.  If less than zero, all wavelengths are used.
-        Setting this to some positive number decreses the scaling
-        constant in the O(N_out * N_in) algorithm used here.
+        Number of sigma away from the output wavelength to consider in the
+        integral.  If less than zero, all wavelengths are used.  Setting this
+        to some positive number decreses the scaling constant in the O(N_out *
+        N_in) algorithm used here.
+
+    :returns flux:
+        The output smoothed flux vector, same length as ``outwave``.
     """
     if input_res <= 0:
         sigma_eff = sigma
@@ -165,29 +237,73 @@ def smooth_wave(wave, spec, outwave, sigma, nsigma=10,
             good = np.abs(x) < nsigma
             x = x[good]
             _spec = spec[good]
-#            _wave = wave[good]
         else:
             _spec = spec
-#            _wave = wave
         f = np.exp(-0.5 * x**2)
         flux[i] = np.trapz(f * _spec, x) / np.trapz(f, x)
     return flux
 
 
+def smooth_wave_fft(wavelength, spectrum, outwave, sigma_out=1.0,
+                    sigma_in=0.0, **extras):
+    """Smooth a spectrum in wavelength space, using FFTs.  This is fast, but
+    makes some assumptions about the input spectrum, and can have some
+    issues at the ends of the spectrum depending on how it is padded.
+
+    :param wavelength:
+        Wavelength vector of the input spectrum.
+
+    :param spectrum:
+        Flux vector of the input spectrum.
+
+    :param outwave:
+        Desired output wavelength vector.
+
+    :param sigma:
+        Desired resolution (*not* FWHM) in wavelength units.
+
+    :param sigma_in:
+        Resolution of the input, in wavelength units (dispersion not FWHM).
+
+    :returns flux:
+        The output smoothed flux vector, same length as ``outwave``.
+    """
+    # restrict wavelength range (for speed)
+    # should also make nearest power of 2
+    wave, spec = resample_wave(wavelength, spectrum, linear=True)
+    
+    # The kernel width for the convolution.
+    sigma = np.sqrt(sigma_out**2 - sigma_in**2)
+    if sigma < 0:
+        return np.interp(wave, outwave, flux)
+    
+    # get grid resolution (*not* the resolution of the input spectrum) and make
+    # sure it's nearly constant.  Should be by design (see resample_wave)
+    Rgrid = np.diff(wave)
+    assert Rgrid.max() / Rgrid.min() < 1.05
+    dw = np.median(Rgrid)
+    
+    # Do the convolution
+    spec_conv = smooth_fft(dw, spec, sigma)
+    # interpolate onto output grid
+    if outwave is not None:
+        spec_conv = np.interp(outwave, wave, spec_conv)
+    return spec_conv
+
+
 def smooth_lsf(wave, spec, outwave, lsf=None, return_kernel=False,
                **kwargs):
-    """Broaden a spectrum using a wavelength dependent line spread
-    function.  This function is only approximate because it doesn't
-    actually do the integration over pixels, so for sparsely sampled
-    points you'll have problems.
+    """Broaden a spectrum using a wavelength dependent line spread function.
+    This function is only approximate because it doesn't actually do the
+    integration over pixels, so for sparsely sampled points you'll have
+    problems.
 
     :param wave:
         Input wavelengths.
 
     :param lsf:
-        A function that returns the gaussian dispersion at each
-        wavelength.  This is assumed to be in sigma unless ``fwhm`` is
-        ``True``
+        A function that returns the gaussian dispersion at each wavelength.
+        This is assumed to be in sigma unless ``fwhm`` is ``True``
 
     :param outwave:
         Output wavelengths
@@ -214,6 +330,70 @@ def smooth_lsf(wave, spec, outwave, lsf=None, return_kernel=False,
     if return_kernel:
         return newspec, kernel
     return newspec
+
+
+def smooth_fft(dx, spec, sigma):
+    """
+    :param dx:
+        The wavelength or velocity spacing, same units as sigma
+
+    :param sigma:
+        The width of the gaussian kernel, same units as dx
+
+    :param spec:
+        The spectrum flux vector
+    """
+    # The Fourier coordinate
+    ss = rfftfreq(len(spec), d=dx)
+    # Make the fourier space taper
+    taper = np.exp(-2 * (np.pi ** 2) * (sigma ** 2) * (ss ** 2))
+    ss[0] = 0.01  # hack
+    # Fourier transform the spectrum
+    spec_ff = np.fft.rfft(spec)
+    # Multiply in fourier space
+    ff_tapered = spec_ff * taper
+    # Fourier transform back
+    spec_conv = np.fft.irfft(ff_tapered)
+    return spec_conv
+
+
+def mask_wave(wavelength, R=20000, wlo=0, whi=np.inf, outwave=None,
+              nsigma_pad=20.0, linear=False, **extras):
+    """restrict wavelength range (for speed) but include some padding"""
+    # Base wavelength limits
+    if outwave is not None:
+        wlim = np.array([outwave.min(), outwave.max()])
+    else:
+        wlim = np.array([wlo, whi])
+    # Pad by nsigma * sigma_wave
+    if linear:
+        wlim += nsigma_pad * R * np.array([-1, 1])
+    else:
+        wlim *= (1 + nsigma_pad / R * np.array([-1, 1]))
+    mask = (wavelength > wlim[0]) & (wavelength < wlim[1])
+    return mask
+
+
+def resample_wave(wavelength, spectrum, linear=False):
+    """Resample spectrum, so that the number of elements is the next highest
+    power of two.  Assumes the input spectrum is constant velocity resolution
+    unless ``linear`` is True, in which case it is assumed that the spectrum has
+    constant wavelength resolution (e.g. 1AA)
+    """
+    wmin, wmax = wavelength.min(), wavelength.max()
+    nw = len(wavelength)
+    nnew = 2.0**(np.ceil(np.log2(nw)))
+    if linear:
+        Rgrid = np.diff(wavelength) # in same units as ``wavelength`` 
+        w = np.linspace(wmin, wmax, nnew)
+    else:
+        Rgrid = np.diff(np.log(wavelength))  # actually 1/R
+        lnlam = np.linspace(np.log(wmin), np.log(wmax), nnew)
+        w = np.exp(lnlam)
+    # Make sure the resolution really is nearly constant
+    assert Rgrid.max() / Rgrid.min() < 1.05
+    s = np.interp(w, wavelength, spectrum)
+    return w, s
 
 
 def downsample_onespec(wave, spec, outwave, outres,


### PR DESCRIPTION
Adds functionality for smoothing spectra using FFTs instead of naive slow explicit code, and generally cleans up the smoothing module.

This also makes a small change to StarBasis where the values of the parameter dictionary are forced to be scalar if possible, so they don't have to be explicitly subscripted.