### PR TITLE
HDF5 output

### DIFF
--- a/bsfh/io/write_results.py
+++ b/bsfh/io/write_results.py
@@ -1,6 +1,7 @@
 import pickle, os, subprocess, time
 import numpy as np
 from ..models.parameters import functions_to_names, plist_to_pdict
+import json
 
 __all__ = ["run_command", "write_pickles"]
 
@@ -67,10 +68,16 @@ def write_pickles(run_params, model, obs, sampler, powell_results,
     # results['cetus_version'] = cgh
 
     tt = int(time.time())
-    out = open('{1}_{0}_mcmc'.format(tt, run_params['outfile']), 'wb')
-    pickle.dump(results, out)
-    out.close()
+    with open('{1}_{0}_mcmc'.format(tt, run_params['outfile']), 'wb') as out:
+        pickle.dump(results, out)
 
-    out = open('{1}_{0}_model'.format(tt, run_params['outfile']), 'wb')
-    pickle.dump(model_store, out)
-    out.close()
+    with open('{1}_{0}_model'.format(tt, run_params['outfile']), 'wb') as out:
+        pickle.dump(model_store, out)
+
+
+def hdf5_output(run_params, model, obs, sampler, powell_results,
+                tsample=None, toptimize=None, sampling_initial_center=None):
+    tt = int(time.time())
+    filename = '{1}_{0}.mcmc.h5'.format(tt, run_params['outfile'])
+    with h5py.File(filename) as out:
+        obs = json.dumps(obs)

--- a/bsfh/io/write_results.py
+++ b/bsfh/io/write_results.py
@@ -1,9 +1,13 @@
-import pickle, os, subprocess, time
+import os, subprocess, time
+import pickle, json
 import numpy as np
 from ..models.parameters import functions_to_names, plist_to_pdict
-import json
+try:
+    import h5py
+except:
+    pass
 
-__all__ = ["run_command", "write_pickles"]
+__all__ = ["run_command", "githash", "write_pickles", "write_hdf5"]
 
 def run_command(cmd):
     """Open a child process, and return its exit status and stdout.
@@ -13,6 +17,23 @@ def run_command(cmd):
     out = [s for s in child.stdout]
     w = child.wait()
     return os.WEXITSTATUS(w), out
+
+
+def githash(nofork=False, **extras):
+    """Pull out the git hash for bsfh here.
+    """
+    if not nofork:
+        try:
+            bsfh_dir = os.path.dirname(__file__)
+            bgh = run_command('cd {0}\n git rev-parse HEAD'.format(bsfh_dir)
+                          )[1][0].replace('\n', '')
+        except:
+            print("Couldn't get Prospector git hash")
+            bgh = "Can't get hash for some reason"
+    else:
+        bgh = "Can't check hash (nofork=True)."
+
+    return bgh
 
 
 def write_pickles(run_params, model, obs, sampler, powell_results,
@@ -26,18 +47,7 @@ def write_pickles(run_params, model, obs, sampler, powell_results,
     fragile.
     """
 
-    # Pull out the git hash for bsfh here.
-    nofork = run_params.get('nofork', False)
-    if not nofork:
-        try:
-            bsfh_dir = os.path.dirname(__file__)
-            bgh = run_command('cd {0}\n git rev-parse HEAD'.format(bsfh_dir)
-                          )[1][0].replace('\n', '')
-        except:
-            print("Couldn't get Prospector git hash")
-            bgh = ''
-    else:
-        bgh = ''
+    bgh = githash(**run_params)
 
     results, model_store = {}, {}
 
@@ -75,9 +85,62 @@ def write_pickles(run_params, model, obs, sampler, powell_results,
         pickle.dump(model_store, out)
 
 
-def hdf5_output(run_params, model, obs, sampler, powell_results,
-                tsample=None, toptimize=None, sampling_initial_center=None):
-    tt = int(time.time())
-    filename = '{1}_{0}.mcmc.h5'.format(tt, run_params['outfile'])
-    with h5py.File(filename) as out:
-        obs = json.dumps(obs)
+def write_hdf5(hf, run_params, model, obs, sampler, powell_results,
+               tsample=0.0, toptimize=0.0, sampling_initial_center=None):
+    """Write output and information to an already open HDF5 file object (or
+    group)
+    """
+
+    # ----------------------
+    # High level parameter and version info
+    bgh = githash(**run_params)
+    serialize = {'run_params': run_params,
+                 'model_params': [functions_to_names(p) for p in model.config_list],
+                 'bsfh_version': bgh,
+                 }
+
+    for k, v in list(serialize.items()):
+        try:
+            hf.attrs[k] = json.dumps(v)
+        except(TypeError):
+            hf.attrs[k] = 'Unserializable'
+            print("Could not serialize {}".format(k))
+
+    hf.attrs['optimizer_duration'] = toptimize
+    hf.flush()
+
+    # ----------------------
+    # Sampling info
+    try:
+        sdat = hf['sampling']
+    except(KeyError):
+        sdat = hf.create_group('sampling')
+        sdat.create_dataset('chain', data=sampler.chain)
+        sdat.create_dataset('lnprobability', data=sampler.lnprobability)
+
+    sdat.create_dataset('acceptance', data=sampler.acceptance_fraction)
+    sdat.attrs['rstate'] = sampler.random_state
+    sdat.attrs['sampling_duration'] = tsample
+    hf.flush()
+
+    # ----------------------
+    # Observational data
+    dnames = ['wavelength', 'spectrum', 'unc', 'mask',
+              'maggies', 'maggies_unc', 'phot_mask']
+    odat = hf.create_group('obs')
+    for k, v in list(obs.items):
+        if k == 'filters':
+            try:
+                v = [f.name for f in v]
+            except:
+                pass
+        if v in dnames:
+            odat.create_dataset(k, data=v)
+        else:
+            try:
+                odat.attrs[k] = json.dumps(v)
+            except(TypeError):
+                odat.attrs[k] = 'Unserializable'
+                print("Could not serialize {}".format(k))
+    
+    hf.close()

--- a/bsfh/models/model_setup.py
+++ b/bsfh/models/model_setup.py
@@ -164,23 +164,16 @@ def import_module_from_file(path_to_file):
     return user_module
 
 
-def load_mock(filename, run_params, model, sps):
-    """Load the obs dictionary using mock data.
+def import_module_from_string(source, name, add_to_sys_modules=True):
+    """Well this seems dangerous.
     """
-    from ..utils.obsutils import generate_mock
-    ext = filename.split('.')[-1]
-    mock_info = None
-    if ext == 'py':
-        print('reading py script {}'.format(filename))
-        setup_module = import_module_from_file(filename)
-        mock_info = deepcopy(getattr(setup_module, 'mock_info', None))
-    if mock_info is None:
-        mock_info = run_params.get('mock_info', None)
+    import imp
+    user_module = imp.new_module(name)
+    exec(source, user_module.__dict__)
+    if add_to_sys_modules:
+        sys.modules[name] = user_module
 
-    mockdat = generate_mock(model, sps, mock_info)
-    mockdat = fix_obs(mockdat, **run_params)
-    mockdat['mock_info'] = mock_info
-    return mockdat
+    return user_module
 
 
 def show_syntax(args, ad):

--- a/bsfh/models/parameters.py
+++ b/bsfh/models/parameters.py
@@ -357,6 +357,30 @@ def pdict_to_plist(pdict):
     return plist
 
 
+def names_to_functions(p):
+    """Replace names of functions in a parameter description with the actual
+    functions.
+    """
+    from importlib import import_module
+    for k, v in list(p.items()):
+        try:
+            m = import_module(v[1])
+            f = m.__dict__[v[0]]
+        except:
+            pass
+        else:
+            p[k] = f
+    return p
+
+def functions_to_names(p):
+    """Replace prior and dust functions with the names of those functions.
+    """
+    for k, v in list(p.items()):
+        if callable(v):
+            p[k] = [v.__name__, v.__module__]
+    return p
+
+
 def write_plist(plist, runpars, filename=None):
     """Write the list of parameter dictionaries to a JSON file, taking care to
     replace functions with their names.
@@ -389,27 +413,3 @@ def read_plist(filename, raw_json=False):
     return runpars, modelpars
 
 
-def names_to_functions(p):
-    """Replace names of functions in a parameter description with the actual
-    functions.
-    """
-    # put the dust curve function in
-    if 'dust_curve_name' in p:
-        from sedpy import attenuation
-        p['init'] = attenuation.__dict__[p['dust_curve_name']]
-    # put the prior function in
-    if 'prior_function_name' in p:
-        p['prior_function'] = priors.__dict__[p['prior_function_name']]
-        # print(p['prior_function_name'], p['prior_function'])
-    else:
-        p['prior_function'] = p.get('prior_function', None)
-    return p
-
-
-def functions_to_names(p):
-    """Replace prior and dust functions with the names of those functions.
-    """
-    for k, v in list(p.items()):
-        if callable(v):
-            p[k] = [v.__name__, v.__module__]
-    return p

--- a/bsfh/models/parameters.py
+++ b/bsfh/models/parameters.py
@@ -409,22 +409,7 @@ def names_to_functions(p):
 def functions_to_names(p):
     """Replace prior and dust functions with the names of those functions.
     """
-    pf = p.get('prior_function', None)
-    cond = ((pf in priors.__dict__.values()) and
-            (pf is not None))
-    if cond:
-        p['prior_function_name'] = pf.func_name
-    else:
-        p.pop('prior_function_name', None)
-    _ = p.pop('prior_function', None)
-
-    # replace dust curve functions with name of function
-    if p['name'] == 'dust_curve':
-        from sedpy import attenuation
-        df = p.get('init', None)
-        cond = ((df is not None) and
-                (df in attenuation.__dict__.values()))
-        if cond:
-            p['dust_curve_name'] = df.func_name
-            _ = p.pop('init', None)
+    for k, v in list(p.items()):
+        if callable(v):
+            p[k] = [v.__name__, v.__module__]
     return p

--- a/demo/prospector.py
+++ b/demo/prospector.py
@@ -221,14 +221,19 @@ if __name__ == "__main__":
     # -------------------------
     # Output pickles (and HDF5)
     # -------------------------
-    write_results.write_pickles(rp, model, obsdat,
-                                esampler, powell_guesses,
-                                toptimize=pdur, tsample=edur,
+    outroot = "{0}_{1}".format(rp['outfile'], int(time.time()))
+    write_results.write_pickles(rp, model, obsdat, esampler, powell_guesses,
+                                outroot=outroot, toptimize=pdur, tsample=edur,
                                 sampling_initial_center=initial_center,
                                 post_burnin_center=burn_p0,
                                 post_burnin_prob=burn_prob0)
 
-    
+    hfile, mfile = outroot + '_mcmc.h5', outroot + '_model'
+    write_results.write_hdf5(hfile, rp, model, obsdat, esampler, powell_guesses,
+                             mfile=mfile, toptimize=pdur, tsample=edur,
+                             sampling_initial_center=initial_center,
+                             post_burnin_center=burn_p0,
+                             post_burnin_prob=burn_prob0)
     try:
         pool.close()
     except:

--- a/demo/prospector.py
+++ b/demo/prospector.py
@@ -161,30 +161,25 @@ def halt():
     
 if __name__ == "__main__":
 
-    ################
+    # --------------
     # Setup
-    ################
+    # --------------
     rp = run_params
     rp['sys.argv'] = sys.argv
-    # Reload model and obs from specific files?
-    #model = model_setup.load_model(param_file=clargs['param_file'])
-    #obsdat = model_setup.load_obs(**rp)
-    #chi2args = [model, obsdat]
-    #postkwargs = {'obs':obsdat, 'model':model}
-    # Or just use the globals?
+    # Use the globals
     model = global_model
     obsdat = global_obs
     chi2args = [None, None]
     postkwargs = {}
 
-    #make zeros into tiny numbers
+    # make zeros into tiny numbers
     initial_theta = model.rectify_theta(model.initial_theta)
     if rp.get('debug', False):
         halt()
 
-    #################
+    # -----------------------------------------
     # Initial guesses using powell minimization
-    #################
+    # -----------------------------------------
     if bool(rp.get('do_powell', True)):
         if rp['verbose']:
             print('minimizing chi-square...')
@@ -209,22 +204,23 @@ if __name__ == "__main__":
         initial_center = initial_theta.copy()
         initial_prob = None
 
-    ###################
+    # -------
     # Sample
-    ####################
+    # -------
     if rp['verbose']:
         print('emcee sampling...')
     tstart = time.time()
-    esampler, burn_p0, burn_prob0 = fitting.run_emcee_sampler(lnprobfn, initial_center, model,
-                                       postkwargs=postkwargs, pool=pool, initial_prob=initial_prob,
-                                       **rp)
+    out = fitting.run_emcee_sampler(lnprobfn, initial_center, model,
+                                    postkwargs=postkwargs, initial_prob=initial_prob,
+                                    pool=pool, **rp)
+    esampler, burn_p0, burn_prob0 = out
     edur = time.time() - tstart
     if rp['verbose']:
         print('done emcee in {0}s'.format(edur))
 
-    ###################
-    # Pickle Output
-    ###################
+    # -------------------------
+    # Output pickles (and HDF5)
+    # -------------------------
     write_results.write_pickles(rp, model, obsdat,
                                 esampler, powell_guesses,
                                 toptimize=pdur, tsample=edur,


### PR DESCRIPTION
Implement HDF5 output methods, using datasets to store sampling chains and observational data and attributes to store strings of JSON for other objects.  An HDF5 reader is also implemented which has the same API as the read_pickles method (``results_from()``)

As part of this pull request the emcee sampling is now done using an iterator (instead of run_mcmc) so that, in principle, the sampler state can be periodically flushed to disk and other operations performed (e.g. convergence testing)

As used in demo/prospector.py, both HDF5 and pickles will be written until confidence in the hdf5 output is increased.