### PR TITLE
Reinitialize with covariance

### DIFF
--- a/bsfh/fitting/fitterutils.py
+++ b/bsfh/fitting/fitterutils.py
@@ -44,7 +44,7 @@ def run_emcee_sampler(lnprobf, initial_center, model, verbose=True,
         List of the number of iterations to run in each round of brun-in (for
         removing stuck walkers)
 
-    :param pool:
+    :param pool: (optional)
         A ``Pool`` object, either from ``multiprocessing`` or from
         ``emcee.mpi_pool``.
 
@@ -195,7 +195,7 @@ def reinitialize_ball_covar(pos, prob, threshold=50.0, center=None,
                                 **extras)
     return pnew
 
-            
+
 def reinitialize_ball(pos, prob, center=None, ptiles=[25, 50, 75],
                       disp_floor=0., **extras):
     """Choose the best walker and build a ball around it based on the other
@@ -221,6 +221,36 @@ def resample_until_valid(sampling_function, center, sigma, nwalkers,
     """Sample from the sampling function, with optional clipping to prior
     bounds and resampling in the case of parameter positions that are outside
     complicated custom priors.
+
+    :param sampling_function:
+        The sampling function to use, it must have the calling sequence
+        ``sampling_function(center, sigma, size=size)``
+
+    :param center:
+        The center of the distribution
+
+    :param sigma:
+        Array describing the scatter of the distribution in each dimension.
+        Can be two-dimensional, e.g. to describe a covariant multivariate
+        normal (if the sampling function takes such a thing).
+
+    :param nwalkers:
+        The number of valid samples to produce.
+
+    :param limits: (optional)
+        Simple limits on the parameters, passed to ``clip_ball``.
+
+    :param prior_check: (optional)
+        An object that has a ``lnp_prior`` method which returns the prior
+        probability for a given parameter position.
+
+    :param maxiter:
+        Maximum number of iterations to try resampling before giving up and
+        returning a set of parameter positions at least one of which is not
+        within the prior.
+
+    :returns pnew:
+        New parameter positions, ndarray of shape (nwalkers, ndim)
     """
     invalid = np.ones(nwalkers, dtype=bool)
     pnew = np.zeros([nwalkers, len(center)])

--- a/bsfh/models/parameters.py
+++ b/bsfh/models/parameters.py
@@ -254,11 +254,15 @@ class ProspectorParams(object):
             disp = self.theta * disp
         return disp
 
-    def theta_disp_floor(self, thetas):
+    def theta_disp_floor(self, thetas=None):
         """Get a vector of dispersions for each parameter to use as a floor for
         the walker-calculated dispersions. This can be overridden by subclasses
         """
-        return np.zeros_like(thetas)
+        dfloor = np.zeros(self.ndim)
+        for par, inds in list(self.theta_index.items()):
+            d = self._config_dict[par].get('disp_floor', 0.0)
+            dfloor[inds[0]: inds[1]] = d
+        return dfloor
 
     def clip_to_bounds(self, thetas):
         """Clip a set of parameters theta to within the priors.

--- a/bsfh/models/parameters.py
+++ b/bsfh/models/parameters.py
@@ -10,7 +10,7 @@ param_template = {'name': '', 'N': 1, 'isfree': False,
                   'init': 0.0, 'units': '',
                   'prior_function_name': None, 'prior_args': None}
 
-    
+
 class ProspectorParams(object):
     """
     :param config_list:
@@ -233,8 +233,7 @@ class ProspectorParams(object):
         bounds = [(np.atleast_1d(a)[0], np.atleast_1d(b)[0]) for a, b in bounds]
         return bounds
 
-    def theta_disps(self, initial_thetas, initial_disp=0.1,
-                    fractional_disp=False):
+    def theta_disps(self, default_disp=0.1, fractional_disp=False):
         """Get a vector of absolute dispersions for each parameter to use in
         generating sampler balls for emcee's Ensemble sampler.  This can be
         overridden by subclasses if fractional dispersions are desired.
@@ -246,9 +245,9 @@ class ProspectorParams(object):
         :param fractional_disp: (default: False)
             Treat the dispersion values as fractional dispersions
         """
-        disp = np.zeros(self.ndim) + initial_disp
+        disp = np.zeros(self.ndim) + default_disp
         for par, inds in list(self.theta_index.items()):
-            d = self._config_dict[par].get('init_disp', initial_disp)
+            d = self._config_dict[par].get('init_disp', default_disp)
             disp[inds[0]: inds[1]] = d
         if fractional_disp:
             disp = self.theta * disp
@@ -376,6 +375,7 @@ def names_to_functions(p):
             p[k] = f
     return p
 
+
 def functions_to_names(p):
     """Replace prior and dust functions with the names of those functions.
     """
@@ -415,5 +415,3 @@ def read_plist(filename, raw_json=False):
         p = names_to_functions(p)
 
     return runpars, modelpars
-
-


### PR DESCRIPTION
This PR updates the reinitialization after burn-in rounds to use the means _and_ covariance of the best 50% of walkers when constructing a new set of parameter positions for the next round of burn-in or production. (The old scheme was simply to estimate the scatter in each dimension and center on the best walker)

It also implements a scheme for checking that all new parameter positions are within the support of even complicated linked priors.  Any new positions that fail the check are redrawn from the correlated gaussian until they pass.