### PR TITLE
SSPbasis and compsp

### DIFF
--- a/bsfh/models/__init__.py
+++ b/bsfh/models/__init__.py
@@ -1,4 +1,4 @@
-from .sedmodel import SedModel, CSPModel
-from .parameters import ProspectorParams
+from .sedmodel import ProspectorParams, SedModel, CSPModel
+#from .parameters import ProspectorParams
 
 __all__ = ["SedModel", "CSPModel", "ProspectorParams"]

--- a/bsfh/source_basis/__init__.py
+++ b/bsfh/source_basis/__init__.py
@@ -1,4 +1,6 @@
 from .galaxy_basis import *
 from .star_basis import *
+from .ssp_basis import *
 
-__all__ = ["StellarPopBasis", "CSPBasis", "StarBasis", "BigStarBasis", "to_cgs"]
+__all__ = ["StellarPopBasis", "CSPBasis", "StarBasis", "BigStarBasis",
+           "SSPBasis", "StepSFHBasis", "to_cgs"]

--- a/bsfh/source_basis/__init__.py
+++ b/bsfh/source_basis/__init__.py
@@ -3,4 +3,4 @@ from .star_basis import *
 from .ssp_basis import *
 
 __all__ = ["StellarPopBasis", "CSPBasis", "StarBasis", "BigStarBasis",
-           "SSPBasis", "StepSFHBasis", "to_cgs"]
+           "SSPBasis", "StepSFHBasis", "CompositeSFH", "to_cgs"]

--- a/bsfh/source_basis/ssp_basis.py
+++ b/bsfh/source_basis/ssp_basis.py
@@ -1,6 +1,6 @@
 from itertools import chain
 import numpy as np
-from scipy.special import expi
+from scipy.special import expi, gammainc
 from ..utils.smoothing import smoothspec
 from sedpy.observate import getSED, vac2air, air2vac
 
@@ -27,14 +27,15 @@ to_cgs = lsun/(4.0 * np.pi * (pc*10)**2)
 # change base
 loge = np.log10(np.e)
 
-#minimum time for logarithmic sfhs
-mint_log = 1 #yr
+# minimum time for logarithmic sfhs
+mint_log = 0  # log(yr)
+
 
 class SSPBasis(object):
 
     def __init__(self, compute_vega_mags=False, zcontinuous=1,
                  interp_type='logarithmic', sfh_type='ssp',
-                 flux_interp='linear', mint_log=1e-3, **kwargs):
+                 flux_interp='linear', mint_log=-3, **kwargs):
 
         self.interp_type = interp_type
         self.sfh_type = sfh_type
@@ -64,15 +65,14 @@ class SSPBasis(object):
         wave, ssp_spectra = self.ssp.get_spectrum(tage=0, peraa=True)
         if self.flux_interp == 'logarithmic':
             ssp_spectra = np.log(ssp_spectra)
-        masses = self.ssp_weights
+        masses = self.all_ssp_weights
         spectrum = (masses[1:, None] * ssp_spectra).sum(axis=0)
-        # Add the t=0 spectrum, using the t_1 spectrum
-        spectrum += masses[0] * ssp_spectra[0,:]
+        # Add the t_0 spectrum, using the t_1 spectrum
+        spectrum += masses[0] * ssp_spectra[0, :]
         if self.flux_interp == 'logarithmic':
             spectrum = np.exp(spectrum)
         return wave, spectrum
-            
-        
+
     def get_spectrum(self, outwave=None, filters=None, **params):
         """
         :returns spec:
@@ -80,13 +80,16 @@ class SSPBasis(object):
 
         :returns phot:
             Photometry in maggies
+
+        :returns x:
+            A generic blob. can be used to return e.g. present day masses,
+            total masses, etc.
         """
-        
         wave, spectrum = self.get_galaxy_spectrum(**params)
         # redshifting
         a = 1 + self.params.get('zred', 0)
         wa, sa = vac2air(wave) * a, spectrum / a
-        
+
         # observed frame photometry after converting to f_lambda
         # (but not dividing by 4* !pi *r^2 or converting from Lsun to cgs)
         if filters is not None:
@@ -107,22 +110,9 @@ class SSPBasis(object):
         # distance dimming and unit conversion
         dist10 = self.params.get('lumdist', 1e-5)/1e-5  # d in units of 10pc
         conv = lsun / (4 * np.pi * (dist10*pc*10)**2)
-        
+
         # distance dimming
-        return smspec * conv , phot * conv, masses.sum()
-
-    @property
-    def ssp_weights(self):
-        masses = self.params['mass']
-        w = mass * self.single_age_weights(self, ages)
-
-    def weights(self, ages):
-        """This is broken
-        """
-        ind = np.searchsorted(self.logage, ages)
-        right =  (ages - self.logage[ind]) / dt[ind]
-        w[ind] += right
-        w[ind+1] += 1 - right
+        return smspec * conv, phot * conv, None
 
     def smoothspec(self, wave, spec, sigma, outwave=None, **kwargs):
         outspec = smoothspec(wave, spec, sigma, outwave=outwave, **kwargs)
@@ -136,16 +126,20 @@ class SSPBasis(object):
     def wavelengths(self):
         return self.ssp.wavelengths
 
+
 class StepSFHBasis(SSPBasis):
 
     @property
-    def ssp_weights(self):
+    def all_ssp_weights(self):
         ages = self.params['agebins']
         masses = self.params['mass']
         w = np.zeros(len(self.logage))
+        # Loop over age bins
         # Should cache the bin weights when agebins not changing.  But this is
         # not very time consuming for few enough bins.
         for (t1, t2), mass in zip(ages, masses):
+            params = {'tage': t2, 'sf_trunc': t2 - t1}
+            #w += mass * self.ssp_weights(self.func, regular_limits, params)
             w += mass * self.bin_weights(t1, t2)[1:]
         return w
 
@@ -155,23 +149,24 @@ class StepSFHBasis(SSPBasis):
         weights are such that one solar mass will have formed during the bin
         (i.e. SFR = 1/(amax-amin))
 
-        This computes weights using \int_tmin^tmax dt (\log t_i - \log t) / (\log
-        t_{i+1} - \log t_i) but see sfh.tex for the detailed calculation and
-        the linear time interpolation case.
+        This computes weights using \int_tmin^tmax dt (\log t_i - \log t) /
+        (\log t_{i+1} - \log t_i) but see sfh.tex for the detailed calculation
+        and the linear time interpolation case.
         """
         if self.interp_type == 'linear':
             sspages = np.insert(10**self.logage, 0, 0)
-            func = self._linear
+            func = constant_linear
             mass = amax - amin
         elif self.interp_type == 'logarithmic':
             sspages = np.insert(self.logage, 0, 0)
-            func = self._logarithmic
+            func = constant_logarithmic
             mass = 10**amax - 10**amin
 
         assert amin >= sspages[1]
         assert amax <= sspages.max()
 
-        # below could be done by using two separate dt vectors instead of two age vectors
+        # below could be done by using two separate dt vectors instead of two
+        # age vectors
         ages = np.array([sspages[:-1], sspages[1:]])
         dt = np.diff(ages, axis=0)
         tmin, tmax = np.clip(ages, amin, amax)
@@ -181,81 +176,151 @@ class StepSFHBasis(SSPBasis):
         left, right = (func(ages, tmax) - func(ages, tmin)) / dt
         # put into full array
         ww = np.zeros(len(sspages))
-        ww[:-1] += right # last element has no sub-bin to the right
-        ww[1:] += -left # first element has no subbin to the left.  also, need to flip sign
+        ww[:-1] += right  # last element has no sub-bin to the right
+        ww[1:] += -left  # need to flip sign
 
         # normalize to 1 solar mass formed and return
         return ww / mass
-
-    def _linear(self, ages, t):
-        """Linear interpolation of linear times, constant SFR.
-        """
-        return ages * t - t**2 / 2
-
-    def _logarithmic(self, logages, logt):
-        """Linear interpolation of logarithmic times, constant SFR.
-        """
-        t = 10**logt
-        return logages * t - t * (logt - np.log10(np.e))
 
 
 class CompositeSFH(SSPBasis):
 
     def configure(self):
-        fname = '{0}_{1}'.format(self.sfh_type, self.interp_type)
-        # is this the right pattern?
-        self.func = globals()[fname]
+        """This reproduces FSPS-like combinations of SFHs.  Note that the
+        *same* parameter set is passed to each component in the combination
+        """
+        sfhs = [self.sfh_type]
+        limits = len(sfhs) * ['regular']
+        if 'simha' in self.sfh_type:
+            sfhs = ['delaytau', 'linear']
+            limits = ['regular', 'simha']
+
+        fnames = ['{0}_{1}'.format(f, self.interp_type) for f in sfhs]
+        lnames = ['{}_limits'.format(f) for f in limits]
+        self.funcs = [globals()[f] for f in fnames]
+        self.limits = [globals()[f] for f in lnames]
+
         if self.interp_type == 'linear':
             sspages = np.insert(10**self.logage, 0, 0)
         elif self.interp_type == 'logarithmic':
-            sspages = np.insert(self.logage, 0, np.log10(self.mint_log))
+            sspages = np.insert(self.logage, 0, self.mint_log)
         self.ages = np.array([sspages[:-1], sspages[1:]])
         self.dt = np.diff(self.ages, axis=0)
-            
+
     @property
-    def ssp_weights(self):
-        tmin, tmax = self.integration_limits(self.ages)
-        left, right = (self.func(self.ages, tmax, **self.params) -
-                       self.func(self.ages, tmin, **self.params)) / self.dt
-        #put into full array, shifting the `right` terms by 1 element
+    def _limits(self):
+        pass
+
+    @property
+    def _funcs(self):
+        pass
+
+    @property
+    def all_ssp_weights(self):
+
+        # Full output weight array.  We keep separate vectors for each
+        # component so we can renormalize after the loop, but for many
+        # components it would be better to renormalize and sum within the loop
+        ww = np.zeros([len(self.funcs), self.ages.shape[-1] + 1])
+
+        # Loop over components.  Note we are sending the same params to every component
+        for i, (limit, func) in enumerate(zip(self.limits, self.funcs)):
+            ww[i, :] = self.ssp_weights(func, limit, self.params)
+
+        # renormalize each component to 1 Msun
+        ww /= ww.sum(axis=1)[:, None]
+        # apply relative normalizations
+        ww *= self.normalizations(**self.params)[:, None]
+        # And finally add all components together and renormalize again to
+        # 1Msun and return
+        return ww.sum(axis=0) / ww.sum()
+
+    def ssp_weights(self, integral, limit_function, params, **extras):
+        # build full output weight vector
         ww = np.zeros(self.ages.shape[-1] + 1)
-        ww[:-1] += right  # last element has no sub-bin to the right
-        ww[1:] += -left   # first element has no subbin to the left.  also, need to flip sign
+        tmin, tmax = limit_function(self.ages, mint_log=self.mint_log,
+                                    interp_type=self.interp_type, **params)
+        left, right = (integral(self.ages, tmax, **params) -
+                       integral(self.ages, tmin, **params)) / self.dt
+        # Put into full array, shifting the `right` terms by 1 element
+        ww[:-1] += right  # last SSP has no sub-bin to the right
+        ww[1:] += -left   # need to flip sign
 
-        # Note that ww[1] = right[1] + left[0], where left[0] is the integral
-        # from tmin,0 to tmax,0 of dt*SFR(t) * (sspages[0] - t)/(sspages[1] - sspages[0])
+        # Note that now ww[i,1] = right[1] - left[0], where
+        # left[0] is the integral from tmin,0 to tmax,0 of
+        # SFR(t) * (sspages[0] - t)/(sspages[1] - sspages[0]) and
+        # right[1] is the integral from tmin,1 to tmax,1 of
+        # SFR(t) * (sspages[2] - t)/(sspages[2] - sspages[1])
+        return ww
 
-        #if simha in self.sfh_type:
-        #  #add the linear portion
-        #  tmin, tmax = self.simha_integration_limits(self.ages)
-        #  left, right = (func(self.ages, tmax, **self.params) -
-        #                 func(self.ages, tmin, **self.params)) / self.dt
-        #  ww[:-1] += right
-        #  ww[1:] -= left
-        # normalize to 1 solar mass formed and return
-        return ww / ww.sum()
-        
-    def integration_limits(self, ages):
-        tage = self.params['tage']
-        tq = (tage - self.params.get('sf_trunc', tage))
-        if self.interp_type == 'logarithmic':
-            tq = np.log10(np.max([tq, self.mint_log]))
-            tage = np.log10(np.max([tage, self.mint_log]))
+    def normalizations(self, tage=0., sf_trunc=0, sf_slope=0, const=0,
+                       fburst=0, tau=0., **extras):
+        if (sf_trunc <= 0) or (sf_trunc > tage):
+            Tmax = tage
+        else:
+            Tmax = sf_trunc
+        # Tau models.  SFH=1 -> power=1; SFH=4,5 -> power=2
+        if ('delay' in self.sfh_type) or ('simha' in self.sfh_type):
+            power = 2
+        else:
+            power = 1
+        mass_tau = tau * gammainc(power, Tmax/tau)
+        sfr_q = (Tmax/tau)**(power-1) * np.exp(-Tmax/tau)
+
+        # linear.  integral of (1 - m * (T - Tmax)) from Tmax to Tzero
+        Tz = Tmax + 1/np.float64(sf_slope)
+        if (Tz < Tmax) or (Tz > tage) or (not np.isfinite(Tz)):
+            Tz = tage
+        m = sf_slope
+        mass_linear = (Tz - Tmax) - m/2*(Tz**2 + Tmax**2) + m*Tz*Tmax
+
+        # normalize the linear portion relative to the tau portion
+        norms = np.array([1, mass_linear * sfr_q / mass_tau])
+        norms /= norms.sum()
+        # now add in constant and burst
+        if (const > 0) or (fburst > 0):
+            norms = (1-fburst-const) * norms
+            norms.tolist().extend([const, fburst])
+        return np.array(norms)
+
+
+def regular_limits(ages, tage=0., sf_trunc=0., mint_log=-3,
+                   interp_type='logarithmic', **extras):
+        # get the truncation time in units of lookback time
+        if (sf_trunc <= 0) or (sf_trunc > tage):
+            tq = 0
+        else:
+            tq = tage - sf_trunc
+        if interp_type == 'logarithmic':
+            tq = np.max([np.log10(tq), mint_log])
+            tage = np.max([np.log10(tage), mint_log])
         return np.clip(ages, tq, tage)
 
-    def simha_integration_limits(self, ages):
-        tage = self.params['tage']
-        tq = tage - self.params.get('sf_trunc', tage)
-        tzero = tq -  1. / self.params.get('sf_slope', 0)# fix this to deal with slope=0
-        tzero = np.clip(tzero, 0) #fix this for negative slopes
+
+def simha_limits(ages, tage=0., sf_trunc=0, sf_slope=0., mint_log=-3,
+                 interp_type='logarithmic', **extras):
+        # get the truncation time in units of lookback time
+        if (sf_trunc <= 0) or (sf_trunc > tage):
+            tq = 0
+        else:
+            tq = tage - sf_trunc
+        if interp_type == 'logarithmic':
+            tq = np.max([np.log10(tq), mint_log])
+            tage = np.max([np.log10(tage), mint_log])
+        tzero = tq - 1. / np.float64(sf_slope)
+        if (tzero > tq) or (tzero <= 0) or (not np.isfinite(tzero)):
+            tzero = 0.
         return np.clip(ages, tzero, tq)
-    
-    def norm(self):
-        return self.params['K'] * self.params['tau'] * np.exp(-self.params['tage']/ self.params['tau'])
 
 
 def constant_linear(ages, t, **extras):
-    """SFR = 1
+    """Indefinite integral for SFR = 1
+
+    :param ages:
+        Linear age(s) of the SSPs.
+
+    :param t:
+        Linear time at which to evaluate the indefinite integral
     """
     return ages * t - t**2 / 2
 
@@ -298,14 +363,14 @@ def delaytau_logarithmic(logages, logt, tau=None, tage=None, **extras):
     return term - (tage / tau + 1) * h
 
 
-def linear_linear(ages, t, tage=None, sf_slope=None, **extras):
+def linear_linear(ages, t, tage=None, sf_slope=0., **extras):
     """SFR = [1 - sf_slope * (tage-t)]
     """
     k = 1 - sf_slope * tage
-    return k * ages * t + (sf_slope * ages - k) * t**2 / 2 - sf_slope * t**3 / 3
+    return k * ages * t + (sf_slope*ages - k) * t**2 / 2 - sf_slope * t**3 / 3
 
 
-def linear_logarithmic(logages, logt, tage=None, sf_slope=None, b=0, **extras):
+def linear_logarithmic(logages, logt, tage=None, sf_slope=0., **extras):
     """SFR = [1 - sf_slope * (tage-t)]
     """
     t = 10**logt
@@ -315,14 +380,15 @@ def linear_logarithmic(logages, logt, tage=None, sf_slope=None, b=0, **extras):
     return term1 + term2
 
 
-def delta_linear(ages, t, t_burst=None):
+def burst_linear(ages, t, t_burst=None):
     """Burst.  SFR = \delta(t-t_burst)
     """
-    #return ages - t_burst
+    # return ages - t_burst
     raise(NotImplementedError)
 
-def delta_logarithmic(logages, logt, t_burst=None):
+
+def burst_logarithmic(logages, logt, t_burst=None):
     """Burst.  SFR = \delta(t-t_burst)
     """
-    #return logages - np.log10(t_burst)
+    # return logages - np.log10(t_burst)
     raise(NotImplementedError)

--- a/bsfh/source_basis/ssp_basis.py
+++ b/bsfh/source_basis/ssp_basis.py
@@ -12,7 +12,16 @@ try:
 except(ImportError):
     pass
 
-__all__ = ["SSPBasis"]
+__all__ = ["SSPBasis", "StepSFHBasis"]
+
+
+# Useful constants
+lsun = 3.846e33
+pc = 3.085677581467192e18  # in cm
+lightspeed = 2.998e18  # AA/s
+jansky_mks = 1e-26
+# value to go from L_sun/AA to erg/s/cm^2/AA at 10pc
+to_cgs = lsun/(4.0 * np.pi * (pc*10)**2)
 
 
 class SSPBasis(object):
@@ -23,33 +32,106 @@ class SSPBasis(object):
         self.interp_type = interp_type
         self.ssp = fsps.StellarPopulation(compute_vega_mags=compute_vega_mags,
                                           zcontinuous=zcontinuous)
+        self.ssp.params['sfh'] = 0
+        self.reserved_params = []
         self.params = {}
+        self.update(**kwargs)
 
-    def get_spectrum(self, outwave=None, filters=None, **params):
-        self.update(**params)
-        w, ssp_spectra = self.ssp.get_spectrum(tage=0, peraa=True)
-        spectrum = self.ssp_weights[:,None] * self.ssp_spectra).sum(axis=0)
-
-        #distance dimming
-
-        #photometry
-
-        #smoothing
-        
     def update(self, **params):
         for k, v in params.items():
             self.params[k] = v
+            if k in self.reserved_params:
+                continue
             if k in self.ssp.params.all_params:
                 self.ssp.params[k] = v
+        assert self.ssp.params['sfh'] == 0
 
-    def ssp_weights(timebins, masses):
-        for (t1, t2), mass in zip(timebins, masses):
+    def get_spectrum(self, outwave=None, filters=None, **params):
+        """
+        :returns spec:
+            Spectrum in erg/s/AA/cm^2
+
+        :returns phot:
+            Photometry in maggies
+        """
+        self.update(**params)
+        wave, ssp_spectra = self.ssp.get_spectrum(tage=0, peraa=True)
+        masses = self.ssp_weights
+        spectrum = (masses[:, None] * ssp_spectra).sum(axis=0)
+
+        # redshifting
+        a = 1 + self.params.get('zred', 0)
+        wa, sa = vac2air(wave) * a, spectrum / a
+        
+        # observed frame photometry after converting to f_lambda
+        # (but not dividing by 4* !pi *r^2 or converting from Lsun to cgs)
+        if filters is not None:
+            mags = getSED(wa, sa, filters)
+            phot = np.atleast_1d(10**(-0.4 * mags))
+        else:
+            phot = 0.0
+
+        # smoothing
+        if outwave is None:
+            outwave = wa
+        if 'sigma_smooth' in self.params:
+            smspec = self.smoothspec(wa, sa, self.params['sigma_smooth'],
+                                     outwave=outwave, **self.params)
+        else:
+            smspec = np.interp(outwave, wa, sa, left=0, right=0)
+
+        # distance dimming and unit conversion
+        dist10 = self.params.get('lumdist', 1e-5)/1e-5  # d in units of 10pc
+        conv = lsun / (4 * np.pi * (dist10*pc*10)**2)
+        
+        # distance dimming
+        return smspec * conv , phot * conv, masses.sum()
+
+    @property
+    def ssp_weights(self):
+        masses = self.params['mass']
+        w = mass * self.single_age_weights(self, ages)
+
+    def weights(self, ages):
+        """This is broken
+        """
+        ind = np.searchsorted(self.logage, ages)
+        right =  (ages - self.logage[ind]) / dt[ind]
+        w[ind] += right
+        w[ind+1] += 1 - right
+
+    def smoothspec(self, wave, spec, sigma, outwave=None, **kwargs):
+        outspec = smoothspec(wave, spec, sigma, outwave=outwave, **kwargs)
+        return outspec
+
+    @property
+    def logage(self):
+        return self.ssp.ssp_ages
+
+    @property
+    def wavelengths(self):
+        return self.ssp.wavelengths
+
+class StepSFHBasis(SSPBasis):
+
+    @property
+    def ssp_weights(self):
+        ages = self.params['agebins']
+        masses = self.params['mass']
+        w = np.zeros(len(self.logage))
+        # Should cache the bin weights when agebins not changing.  But this is
+        # not very time consuming for few enough bins.
+        for (t1, t2), mass in zip(ages, masses):
             w += mass * self.bin_weights(t1, t2)[1:]
         return w
 
-    def bin_weights(amin, amax):
+    def bin_weights(self, amin, amax):
         """Compute normalizations required to get a piecewise constant
         SFH (SFR=1) within an age bin.  This is super complicated and obscured.
+
+        This computes weights using \int_tmin^tmax dt (\log t_i - \log t) / (\log
+        t_{i+1} - \log t_i) but see sfh.tex for the detailed calculation and
+        the linear time interpolation case.
         """
         if self.interp_type == 'linear':
             sspages = np.insert(10**self.logage, 0, 0)
@@ -60,8 +142,8 @@ class SSPBasis(object):
             func = self._logarithmic
             mass = 10**amax - 10**amin
 
-        assert amin > 0
-        assert amax < sspages.max()
+        assert amin >= sspages[1]
+        assert amax <= sspages.max()
 
         # below could be done by using two separate dt vectors instead of two age vectors
         ages = np.array([sspages[:-1], sspages[1:]])
@@ -77,20 +159,15 @@ class SSPBasis(object):
         ww[1:] += -left # first element has no subbin to the left.  also, need to flip sign
 
         # normalize to 1 solar mass formed and return
-        return ww / mass        
+        return ww / mass
 
     def _linear(self, ages, t):
-        """Linear interpolation of linear times
+        """Linear interpolation of linear times, constant SFR.
         """
         return ages * t - t**2 / 2
 
     def _logarithmic(self, logages, logt):
-        """Linear interpolation of logarithmic times
+        """Linear interpolation of logarithmic times, constant SFR.
         """
         t = 10**logt
         return logages * t - t * (logt - np.log10(np.e))
-
-    @property
-    def logage(self):
-        return self.ssp.ssp_ages
-

--- a/bsfh/source_basis/ssp_basis.py
+++ b/bsfh/source_basis/ssp_basis.py
@@ -126,8 +126,10 @@ class StepSFHBasis(SSPBasis):
         return w
 
     def bin_weights(self, amin, amax):
-        """Compute normalizations required to get a piecewise constant
-        SFH (SFR=1) within an age bin.  This is super complicated and obscured.
+        """Compute normalizations required to get a piecewise constant SFH
+        within an age bin.  This is super complicated and obscured.  The output
+        weights are such that one solar mass will have formed during the bin
+        (i.e. SFR = 1/(amax-amin))
 
         This computes weights using \int_tmin^tmax dt (\log t_i - \log t) / (\log
         t_{i+1} - \log t_i) but see sfh.tex for the detailed calculation and
@@ -151,7 +153,7 @@ class StepSFHBasis(SSPBasis):
         tmin, tmax = np.clip(ages, amin, amax)
 
         # get contributions from SSP sub-bin to the left and from SSP sub-bin
-        # to the right, using linear interpolation in linear time
+        # to the right
         left, right = (func(ages, tmax) - func(ages, tmin)) / dt
         # put into full array
         ww = np.zeros(len(sspages))

--- a/bsfh/source_basis/ssp_basis.py
+++ b/bsfh/source_basis/ssp_basis.py
@@ -1,0 +1,96 @@
+from itertools import chain
+import numpy as np
+from ..utils.smoothing import smoothspec
+from sedpy.observate import getSED, vac2air, air2vac
+
+try:
+    import fsps
+except(ImportError):
+    pass
+try:
+    from astropy.cosmology import WMAP9 as cosmo
+except(ImportError):
+    pass
+
+__all__ = ["SSPBasis"]
+
+
+class SSPBasis(object):
+
+    def __init__(self, compute_vega_mags=False, zcontinuous=1,
+                 interp_type='logarithmic', **kwargs):
+
+        self.interp_type = interp_type
+        self.ssp = fsps.StellarPopulation(compute_vega_mags=compute_vega_mags,
+                                          zcontinuous=zcontinuous)
+        self.params = {}
+
+    def get_spectrum(self, outwave=None, filters=None, **params):
+        self.update(**params)
+        w, ssp_spectra = self.ssp.get_spectrum(tage=0, peraa=True)
+        spectrum = self.ssp_weights[:,None] * self.ssp_spectra).sum(axis=0)
+
+        #distance dimming
+
+        #photometry
+
+        #smoothing
+        
+    def update(self, **params):
+        for k, v in params.items():
+            self.params[k] = v
+            if k in self.ssp.params.all_params:
+                self.ssp.params[k] = v
+
+    def ssp_weights(timebins, masses):
+        for (t1, t2), mass in zip(timebins, masses):
+            w += mass * self.bin_weights(t1, t2)[1:]
+        return w
+
+    def bin_weights(amin, amax):
+        """Compute normalizations required to get a piecewise constant
+        SFH (SFR=1) within an age bin.  This is super complicated and obscured.
+        """
+        if self.interp_type == 'linear':
+            sspages = np.insert(10**self.logage, 0, 0)
+            func = self._linear
+            mass = amax - amin
+        elif self.interp_type == 'logarithmic':
+            sspages = np.insert(self.logage, 0, 0)
+            func = self._logarithmic
+            mass = 10**amax - 10**amin
+
+        assert amin > 0
+        assert amax < sspages.max()
+
+        # below could be done by using two separate dt vectors instead of two age vectors
+        ages = np.array([sspages[:-1], sspages[1:]])
+        dt = np.diff(ages, axis=0)
+        tmin, tmax = np.clip(ages, amin, amax)
+
+        # get contributions from SSP sub-bin to the left and from SSP sub-bin
+        # to the right, using linear interpolation in linear time
+        left, right = (func(ages, tmax) - func(ages, tmin)) / dt
+        # put into full array
+        ww = np.zeros(len(sspages))
+        ww[:-1] += right # last element has no sub-bin to the right
+        ww[1:] += -left # first element has no subbin to the left.  also, need to flip sign
+
+        # normalize to 1 solar mass formed and return
+        return ww / mass        
+
+    def _linear(self, ages, t):
+        """Linear interpolation of linear times
+        """
+        return ages * t - t**2 / 2
+
+    def _logarithmic(self, logages, logt):
+        """Linear interpolation of logarithmic times
+        """
+        t = 10**logt
+        return logages * t - t * (logt - np.log10(np.e))
+
+    @property
+    def logage(self):
+        return self.ssp.ssp_ages
+

--- a/doc/text/sfhs.tex
+++ b/doc/text/sfhs.tex
@@ -15,8 +15,13 @@
 \newcommand{\tinterval}{\right|_{\tmin[,i]}^{\tmax[,i]}}
 \newcommand{\clip}[3][]{{#1}_{\top {#2}}^{\bot {#3}}}
 
-\newcommand{\sftrunc}{t_{\mathrm{trunc}}}
+\newcommand{\sftrunc}{T_{\mathrm{trunc}}}
 \newcommand{\tage}{t_{\mathrm{age}}} 
+\newcommand{\sfzero}{T_{\mathrm{zero}}}
+\newcommand{\tzero}{t_{\circ}}
+\newcommand{\sfslope}{m_{\mathrm{SF}}} 
+
+
 \begin{document}
 \author{B. Johnson}
 
@@ -46,14 +51,16 @@ W_{i, \mathrm{left}} & = & \int_{\tmin[,i-1]}^{\tmax[,i-1]} dt \, \mathrm{SFR}(t
 \end{eqnarray}
 where $\clip[x]{a}{b}$ denotes $x$ \emph{clipped} to the interval $(a,b)$. If we take $\mathrm{SFR}(t) = 1$ then we can define
 \begin{eqnarray}
-g_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \nonumber  \\
- & = & \left. \frac{1}{t_{i+1} - t_i} \, \left[ t_{i+1} \, t - \frac{t^2}{2} \right] \tinterval
+g_i(x) & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{x - t}{t_{i+1}  - t_i} \nonumber  \\
+ & = & \left. \frac{1}{t_{i+1} - t_i} \, \left[ x\, t - \frac{t^2}{2} \right] \tinterval
 \end{eqnarray}
 which leads to
 \begin{eqnarray}
-W_i & = & g_{i} - g_{i-1}
+W_i & = & g_{i}(t_{i+1}) - g_{i-1}(t_{i-1})
 \end{eqnarray}
-and one only has to calculate the ${g_i}$ once and then take differences between shifted versions to obtain the total weights.
+and one only has to calculate the $\{g_i(t_i)\}, \{g_i(t_{i+1})\}$ once and then take differences between shifted versions to obtain the total weights.
+Note that for the smallest $i$ we define $g_{i-1}(t_{i-1})\equiv 0$ (there is no younger or ``left'' sub-bin) 
+and for the largest $i$ we define $g_{i}(t_{i+1}) \equiv 0$ (there is no older or ``right'' sub-bin) .
 
 This formalism works even if $\amin$ and $\amax$ both fall between the same $t_i$ and $t_{i+1}$; that is, if the desired bin is narrower than the SSP defined sub-bins.
 It also works if a sub-bin falls completely outside the $(amin, amax)$ interval.
@@ -67,22 +74,35 @@ w_{i}(t) & = & \frac{ \log t_{i+1} - \log t}{ \log t_{i+1}  - \log t_i} \nonumbe
 \end{eqnarray}
 in the first set of equations above. The we simply replace $g_i$ by $s_i$ defined as 
 \begin{eqnarray}
-s_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{\log t_{i+1} - \log t}{\log t_{i+1}  - \log t_i} \nonumber \\
- & = & \left. \frac{1}{\log t_{i+1} - \log t_i} \left[ t \, \log t_{i+1} - t \log\left(\frac{t}{e}\right) \right] \tinterval
+s_i(x) & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{x - \log t}{\log t_{i+1}  - \log t_i} \nonumber \\
+ & = & \left. \frac{1}{\log t_{i+1} - \log t_i} \left[ t \, x- t \log\left(\frac{t}{e}\right) \right] \tinterval
 \end{eqnarray}
 to obtain a total weight for SSP $i$ of
 \begin{eqnarray}
-W_i & = & s_{i} - s_{i-1} \nonumber
+W_i & = & s_{i}(\log t_{i+1}) - s_{i-1}(\log t_{i-1}) \nonumber
 \end{eqnarray}
 
 The key in both cases is to properly calculate $\tmax$ and keep track of the indices 
 (especially for the first and last SSP, where $s_{i-1}$ and $s_i$ are not defined, respectively.)  
 
 \section{Lookback Time Zero}
+The youngest age for which an SSP spectrum is availables is generally of order 1 Myr.  
+However, we need to account for SF occuring from 0-1 Myr lookback time.
+There's a couple ways to deal with this.  
+Probably the most straightforward is to simply approximate the $t=0$ spectrum by the youngest available SSP.
+
+In the case of logarithmic interpolation one has to define some minimum age, say 1 year, to act as zero.
+In practice the exact choice of minimum age does not matter, 
+as the total weights for the zeroth and first SSP converge such that fractional error is below $\sim 10^{-4}$ for a minimum age less than 10 years or so...
+The totally correct way to do this is to work out the definite integrals properly with $\tmin[,i]=0$.
+
 
 \section{More complex SFHs}
-For more complicated SFH the integrals in the basic definition of $s_i$ must be calculated again by hand, (remembering here that $t$ is \emph{lookback time}.)  
-We define $s_i$ for interpolation in $\log t$ and $g_i$ for interpolation in $t$.
+For more complicated SFH only the integrals in the basic definition of $s_i$ and $g_i$ must be calculated again by hand, 
+(remembering here that $t$ is \emph{lookback time}.)
+We define $s_i(x)$ for interpolation in $\log t$ and $g_i(x)$ for interpolation in $t$.  
+For simplicity and clarity we take the cases $x = \log t_{i+1}$ for $s_i$ and $x = t_{i+1}$ for $g_i$, 
+but substitution for $x$ is trivial (as long as it is not $t$ dependent):
 \begin{eqnarray}
 s_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{\log t_{i+1} - \log t}{\dlt} \\
 g_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{\dt}
@@ -106,13 +126,13 @@ Here we have a SFH defined by three parameters
 \[ 
 \mathrm{SFR}(t) = 
 \begin{cases}
-K \, e^{-T/\tau}, &  \text{if } 0 < T \leq t_{\mathrm{trunc}} \\
+K \, e^{-T/\tau}, &  \text{if } 0 < T \leq \sftrunc \\
 0, & \text{otherwise}
 \end{cases}
 \]
 \begin{eqnarray}
 T & = & \tage - t \nonumber \\
-t_q & = & \tage - t_{\mathrm{trunc}} \nonumber 
+t_q & = & \tage - \sftrunc \nonumber 
 \end{eqnarray}
 where $T$ is defined as the time since the start of star formation, \emph{not} lookback time.  
 The lookback time  (in the reference frame of the galaxy) is given by $t$, which goes from 0 to $\tage$.
@@ -120,7 +140,7 @@ The parameters are:
 $\tage$, the age of the galaxy since the start of SF (\texttt{tage} in FSPS), 
 $\tau$, the $e$-folding time (\texttt{tau} in FSPS), and
 $\sftrunc$, the time since the start of SF that truncation occurs (\texttt{sf\_trunc} in FSPS).
-Note that in the current FSPS definition, $t_{\mathrm{trunc}}=0$ corresponds to no truncation, so it is actually $t_{\mathrm{trunc}} = \tage$ and $t_q=0$.
+Note that in the current FSPS definition, $\sftrunc = 0$ corresponds to no truncation, so it is actually $\sftrunc= \tage$ and $t_q=0$.
 The FSPS \texttt{sf\_start} is basically redundant with \texttt{tage} and confusing so we ignore it.
 
 In this case we have, for the logarithmic time interpolation,
@@ -147,13 +167,13 @@ Here the SFH is also defined by three parameters
 \[ 
 \mathrm{SFR}(t) = 
 \begin{cases}
-K \, T \, e^{-T/\tau}, &  \text{if } 0 < T \leq t_{\mathrm{trunc}} \\
+K \, T \, e^{-T/\tau}, &  \text{if } 0 < T \leq \sftrunc\\
 0, & \text{otherwise}
 \end{cases}
 \]
 \begin{eqnarray}
 T & = & \tage - t \nonumber \\
-t_q & = & \tage - t_{\mathrm{trunc}} \nonumber
+t_q & = & \tage - \sftrunc\nonumber
 \end{eqnarray}
 So now we have
 \begin{eqnarray}
@@ -164,6 +184,7 @@ The first and third terms are fairly straightforward.  The second term is basica
 \begin{eqnarray}
 s_i  & = & \frac{K \, \tau \,  e^{-\tage/\tau}}{\dlt} \left[\left.\left(t\,\log \frac{t}{t_{i+1}} + \tage\,\log t_{i+1}  + \tau\,\log \frac{t_{i+1}}{e}\right) e^{t/\tau}\tinterval - (\tage/\tau+1)\, H_i\right] \quad .
 \end{eqnarray}
+The limits $\tmin$ and $\tmax$ are as for the $\tau$-model above.
 
 For interpolation in linear time, we have
 \begin{eqnarray}
@@ -172,10 +193,61 @@ g_i  & = & \tintegral \, K \, (\tage-t) \, e^{(t-\tage) /\tau}\, \frac{t_{i+1} -
      & = & \frac{K \, \tau \, e^{-\tage/\tau}}{\dt} \left. e^{t/\tau} \, \left[ \tage \, t_{i+1} - (\tage + t_{i+1})\, (t-\tau) + t^2 - 2\, t\, \tau + 2\, \tau^2\right] \tinterval \quad .
 \end{eqnarray}
 
+One could, in principle, redefine the SSP $t_i$ to be in forward time instead of lookback time.  While this would simplify the integrals, keeping them in lookback time is conceptually simpler.
+
 \subsection{Simha}
-This is the SFH from \citet{simha14}.  It is defined by a delayed-$\tau$ SFH until some time $\sftrunc$, after which the SFH is linearly increasing or decreasing with some slope $m_{\mathrm{SF}}$.  The SFR is continuous at $\sftrunc$, but the derivative is not.  For this reason, we will treat the SFH in two separate pieces.  The trick is to get the proper normalization at $\sftrunc$ and, for linearly decreasing SF, find the time where the SF reaches zero. 
+This is the SFH from \citet{simha14}.  
+It is defined by a delayed-$\tau$ SFH until some time $\sftrunc$, after which the SFH is linearly increasing or decreasing with some slope $m_{\mathrm{SF}}$.  
+The SFR is continuous at $\sftrunc$, but the derivative is not.  
+For this reason, we will treat the SFH in two separate pieces.  
+The trick is to get the proper normalization at $\sftrunc$ and, for linearly decreasing SF, find the time where the SF reaches zero. 
+\[ 
+\mathrm{SFR}(t) = 
+\begin{cases}
+K \, T \, e^{-T/\tau}, &  \text{if } 0 < T \leq \sftrunc \\
+L\, \left[1 - \sfslope \, (T - \sftrunc)\right] & \text{if } \sftrunc < T  < \sfzero \\
+0 & \text{otherwise}
+\end{cases}
+\]
+\begin{eqnarray}
+T & = & \tage - t \nonumber \\
+t_q & = & \tage - \sftrunc \nonumber \\
+L & = & K \, \sftrunc \, e^{-\sftrunc/\tau} \nonumber \\
+\sfzero & = & \clip[\left(\sftrunc + \sfslope^{-1}\right)]{\sftrunc}{\tage}, \nonumber \\
+\tzero & = & \clip[\left( t_q - \sfslope^{-1}\right)]{0}{t_q} \nonumber
+\end{eqnarray}
+where $\tzero$ is the \emph{lookback} time at which the SFR becomes zero.
+
+The portion of the SFH that is a delayed-$\tau$ can be dealt with using the formulae in the last section.  The linear portion is relatively straightforward:
+\begin{eqnarray}
+s_i  & = & \tintegral \,  L\, \left[1 - \sfslope \, (t_q - t)\right] \, \frac{\log t_{i+1} - \log t}{\dlt}  \nonumber \\
+      & = & \frac{L}{\dlt} \left.\left[(1-\sfslope\, t_q) \, t \, \left(\log t_{i+1} - \log\frac{t}{e} \right) + \frac{\sfslope \, t^2}{2} \, \left(\log t_{i+1} - \log t +\frac{\log e}{2}\right)  \right] \tinterval \\
+\tmin[,i] & = & \clip[\tzero]{t_i}{t_{i+1}} \nonumber \\
+\tmax[,i] & = & \clip[t_q]{t_i}{t_{i+1}} \quad . \nonumber
+\end{eqnarray}
+
+The linear interpolation version of the linear SFH is given by 
+\begin{eqnarray}
+g_i  & = & \tintegral \,  L\, \left[1 - \sfslope \, (t_q - t)\right] \, \frac{t_{i+1} - t}{\dt}  \nonumber \\
+      & = & \frac{L}{\dt} \left.\left[(1-\sfslope\, t_q) \, t_{i+1} \, t + \left(\sfslope\, t_{i+1} + \sfslope \, t_q -1\right)\, \frac{t^2}{2} - \frac{\sfslope\, t^3}{3}\right] \tinterval
+\end{eqnarray}
 
 
 \subsection{Bursts}
+
+Here we have 
+\[ 
+\mathrm{SFR}(t) = \delta(T - T_{burst})
+\]
+\begin{eqnarray}
+T & = & \tage - t \nonumber \\
+T_{burst} & = & \tage - t_b
+\end{eqnarray}
+
+\begin{eqnarray}
+T & = & \tage - t \nonumber \\
+T_{burst} & = & \tage - t_b
+\end{eqnarray}
+
 
 \end{document}

--- a/doc/text/sfhs.tex
+++ b/doc/text/sfhs.tex
@@ -1,48 +1,181 @@
 \documentclass[12pt, letterpaper, preprint]{aastex} 
 
 \usepackage{graphicx}
+\usepackage{amsmath}
 
 \newcommand{\tmin}[1][]{t_{\mathrm{min} #1}}
 \newcommand{\tmax}[1][]{t_{\mathrm{max} #1}}
 \newcommand{\amin}{a_{\mathrm{min}}}
 \newcommand{\amax} {a_{\mathrm{max}}}
 
+\newcommand{\dlt}{\Delta\log t_i}
+\newcommand{\dt}{\Delta t_i}
+
+\newcommand{\tintegral}{\int_{\tmin[,i]}^{\tmax[,i]} dt}
+\newcommand{\tinterval}{\right|_{\tmin[,i]}^{\tmax[,i]}}
+\newcommand{\clip}[3][]{{#1}_{\top {#2}}^{\bot {#3}}}
+
+\newcommand{\sftrunc}{t_{\mathrm{trunc}}}
+\newcommand{\tage}{t_{\mathrm{age}}} 
 \begin{document}
 \author{B. Johnson}
 
-\begin{center}
-\today
-\end{center}
+%\begin{center}
+%\today
+%\end{center}
 
-We wish to find the proper weighting of discrete SSPs to reproduce the spectrum from SFR occurring within some bin of  lookback times $(\amin, \amax)$.
-If we approximate the spectrum at any lookback time $t$ as a linear interpolation of the spectra at the discrete SSP lookback times $t_i$, for $i=1,...,N$ then we can write the total contribution of SSP $i$ to the total spectrum as a sum of the integrated weight due to SF in the sub-bin to the ``right'' (higher lookback times) and the  sub-bin to the ``left'' (lower lookback times).
+\section{Introduction}
+We wish to find the proper weighting of discrete SSPs to reproduce the spectrum $f$ from SFR occurring within some bin of  lookback times $(\amin, \amax)$.
+We approximate the spectrum $f(t)$ at any lookback time $t$ as a linear interpolation of the (total stellar mass normalized) spectra at the discrete SSP lookback times $t_i$, for $i=1,...,N$ 
+\begin{eqnarray}
+f & = & \int_{\amin}^{\amax} dt \, f(t) \, SFR(t) \nonumber \\
+f(t) & = & w_{i}(t) \, f_i + w_{i+1}(t) \, f_{i+1} \, , \quad t_i < t < t_{i+1}  \nonumber \\
+w_{i}(t) & = & \frac{t_{i+1} - t}{t_{i+1}  - t_i} \nonumber \\
+w_{i+1}(t) & = & 1 - w_i(t) \quad . \nonumber
+\end{eqnarray}
+Then we can write the \emph{total} contribution of SSP $i$ to the total spectrum as a sum of the integrated weight due to SF in the sub-bin to the ``right'' (higher lookback times) and the  sub-bin to the ``left'' (lower lookback times).
 The sub-bins are defined by the spacing of the SSP $t_i$ values. 
 The limits of each integral are determined either by the spacing of the SSP points $t_i$ or, when the bin does not completely span the sub-bin, by the $\amin$ and/or $\amax$ values.
 \begin{eqnarray}
-w_i & = & w_{i, \mathrm{right}} + w_{i, \mathrm{left}} \\
-w_{i, \mathrm{right}} & = & \int_{\tmin[,i]}^{\tmax[,i]} dt \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \\
-w_{i, \mathrm{left}} & = & \int_{\tmin[,i-1]}^{\tmax[,i-1]} dt \, \mathrm{SFR}(t) \, \frac{t - t_{i-1}}{t_{i}  - t_{i-1}} \\
-\tmin[,i] & = & \sup (t_i, \amin) \\
-\tmax[,i] & = & \inf (t_{i+1}, \amax) \\
+W_i & = &  \tintegral \, \mathrm{SFR}(t) \, w_i(t) \nonumber \\
+ & = & W_{i, \mathrm{right}} + W_{i, \mathrm{left}} \nonumber \\
+W_{i, \mathrm{right}} & = & \tintegral \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \nonumber \\
+W_{i, \mathrm{left}} & = & \int_{\tmin[,i-1]}^{\tmax[,i-1]} dt \, \mathrm{SFR}(t) \, \frac{t - t_{i-1}}{t_{i}  - t_{i-1}} \nonumber \\
+\tmin[,i] & = & \clip[\amin]{t_i}{t_{i+1}} \nonumber \\
+\tmax[,i] & = & \clip[\amax]{t_i}{t_{i+1}} \nonumber
 \end{eqnarray}
-If we take $\mathrm{SFR}(t) = 1$ then we can define
+where $\clip[x]{a}{b}$ denotes $x$ \emph{clipped} to the interval $(a,b)$. If we take $\mathrm{SFR}(t) = 1$ then we can define
 \begin{eqnarray}
-s_i & \equiv & \int_{\tmin[,i]}^{\tmax[,i]} dt \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \\
- & = & \left. \frac{1}{t_{i+1} - t_i} \, \left[ t_{i+1} \, t - \frac{t^2}{2} \right] \right| _{\tmin[,i]}^{\tmax[,i]}
+g_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \nonumber  \\
+ & = & \left. \frac{1}{t_{i+1} - t_i} \, \left[ t_{i+1} \, t - \frac{t^2}{2} \right] \tinterval
 \end{eqnarray}
 which leads to
 \begin{eqnarray}
-w_i & = & s_{i} - s_{i-1}
+W_i & = & g_{i} - g_{i-1}
 \end{eqnarray}
-and one only has to calculate the $s_i$ once and then take differences between shifted versions to obtain the total weights. 
+and one only has to calculate the ${g_i}$ once and then take differences between shifted versions to obtain the total weights.
 
-In the case of a linear interpolation in $\log t$, which is probably more appropriate, we would simply replace $s_i$ by 
+This formalism works even if $\amin$ and $\amax$ both fall between the same $t_i$ and $t_{i+1}$; that is, if the desired bin is narrower than the SSP defined sub-bins.
+It also works if a sub-bin falls completely outside the $(amin, amax)$ interval.
+This is because the clipping will cause $\tmin$ and $\tmax$ to be the same for bins not at least partially within the $(amin, amax)$ interval, and thus all integrals will evaluate to zero.
+
+\section{Interpolation in $\log t$}
+
+For the case of a linear interpolation in $\log t$, which is probably more appropriate, we can write
 \begin{eqnarray}
-s_i & \equiv & \int_{\tmin[,i]}^{\tmax[,i]} dt \, \mathrm{SFR}(t) \, \frac{\log t_{i+1} - \log t}{\log t_{i+1}  - \log t_i} \\
- & = & \left. \frac{1}{\log t_{i+1} - \log t_i} \left[ t \, \log t_{i+1} - t \log\left(\frac{t}{e}\right) \right] \right|_{\tmin[,i]}^{\tmax[,i]}
+w_{i}(t) & = & \frac{ \log t_{i+1} - \log t}{ \log t_{i+1}  - \log t_i} \nonumber
+\end{eqnarray}
+in the first set of equations above. The we simply replace $g_i$ by $s_i$ defined as 
+\begin{eqnarray}
+s_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{\log t_{i+1} - \log t}{\log t_{i+1}  - \log t_i} \nonumber \\
+ & = & \left. \frac{1}{\log t_{i+1} - \log t_i} \left[ t \, \log t_{i+1} - t \log\left(\frac{t}{e}\right) \right] \tinterval
+\end{eqnarray}
+to obtain a total weight for SSP $i$ of
+\begin{eqnarray}
+W_i & = & s_{i} - s_{i-1} \nonumber
 \end{eqnarray}
 
-The key in both cases is to properly calculate $\tmax$ and keep track of the indices (especially for the first and last SSP, where $s_{i-1}$ and $s_i$ are not defined, respectively.)  
-For more complicated SFH the integrals in the definition of $s_i$ must be calculated (remembering here that $t$ is \emph{lookback} time.)
+The key in both cases is to properly calculate $\tmax$ and keep track of the indices 
+(especially for the first and last SSP, where $s_{i-1}$ and $s_i$ are not defined, respectively.)  
+
+\section{Lookback Time Zero}
+
+\section{More complex SFHs}
+For more complicated SFH the integrals in the basic definition of $s_i$ must be calculated again by hand, (remembering here that $t$ is \emph{lookback time}.)  
+We define $s_i$ for interpolation in $\log t$ and $g_i$ for interpolation in $t$.
+\begin{eqnarray}
+s_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{\log t_{i+1} - \log t}{\dlt} \\
+g_i & \equiv & \tintegral \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{\dt}
+\end{eqnarray}
+where for brevity we've defined in this section
+\begin{eqnarray}
+\dt & \equiv & t_{i+1} -  t_i  \nonumber \\
+\dlt & \equiv & \log t_{i+1} - \log t_i \nonumber
+\end{eqnarray}
+In general the limits of the integral ($\tmin, \tmax$) will be defined by the SSP temporal grid $\{t_i\}$ as well as any discontinuities in the derivative of the SFR (e.g. the edges of step function already enocountered).
+
+For convenience we will also note that the integral
+\begin{eqnarray}
+H_i & \equiv & \tintegral \, e^{t/\tau} \, \log t \nonumber \\
+  & = & \left. \tau \left[ \log t \, e^{t/\tau} - \log(e) \, \mathrm{Ei}(t/\tau) \right]\tinterval
+\end{eqnarray}
+where Ei is the exponential integral.
+
+\subsection{$\tau$-model}
+Here we have a SFH defined by three parameters
+\[ 
+\mathrm{SFR}(t) = 
+\begin{cases}
+K \, e^{-T/\tau}, &  \text{if } 0 < T \leq t_{\mathrm{trunc}} \\
+0, & \text{otherwise}
+\end{cases}
+\]
+\begin{eqnarray}
+T & = & \tage - t \nonumber \\
+t_q & = & \tage - t_{\mathrm{trunc}} \nonumber 
+\end{eqnarray}
+where $T$ is defined as the time since the start of star formation, \emph{not} lookback time.  
+The lookback time  (in the reference frame of the galaxy) is given by $t$, which goes from 0 to $\tage$.
+The parameters are: 
+$\tage$, the age of the galaxy since the start of SF (\texttt{tage} in FSPS), 
+$\tau$, the $e$-folding time (\texttt{tau} in FSPS), and
+$\sftrunc$, the time since the start of SF that truncation occurs (\texttt{sf\_trunc} in FSPS).
+Note that in the current FSPS definition, $t_{\mathrm{trunc}}=0$ corresponds to no truncation, so it is actually $t_{\mathrm{trunc}} = \tage$ and $t_q=0$.
+The FSPS \texttt{sf\_start} is basically redundant with \texttt{tage} and confusing so we ignore it.
+
+In this case we have, for the logarithmic time interpolation,
+\begin{eqnarray}
+s_i  & = & \tintegral \, K \, e^{(t-\tage) /\tau}\, \frac{\log t_{i+1} - \log t}{\dlt} \nonumber \\
+      & = & \frac{K \, e^{-\tage/\tau}}{\dlt} \left[ \left. \tau \, \log t_{i+1} \, e^{t/\tau} \tinterval -  H_i\right] \nonumber \\
+\tmin[,i] & = & \clip[t_q]{t_i}{t_{i+1}} \nonumber \\
+\tmax[,i] & = & \clip[\tage]{t_i}{t_{i+1}} \quad . \nonumber
+\end{eqnarray}
+Substituting for $H_i$ we have, finally, 
+\begin{eqnarray}
+s_i & = & \left. \frac{K \, \tau \, e^{-\tage/\tau}}{\dlt} \left [(\log t_{i+1} - \log t)\, e^{t/\tau} + 
+          \log(e) \, \mathrm{Ei}(t/\tau)\right]  \tinterval
+\end{eqnarray}
+For interpolation in linear time the integral is a bit more straightforward
+\begin{eqnarray}
+g_i & = & \left. \frac{K \, \tau \, e^{-\tage/\tau}}{\dt} (t_{i+1} - t + \tau)\, e^{t/\tau} \tinterval
+\end{eqnarray}
+where the limits $\tmin$ and $\tmax$ are defined as above.
+One can either calculate the normalization constant $K$ analytically, or simply renormalize the final weights $W_i$ by their sum.
+
+\subsection{Delayed-$\tau$}
+Here the SFH is also defined by three parameters
+\[ 
+\mathrm{SFR}(t) = 
+\begin{cases}
+K \, T \, e^{-T/\tau}, &  \text{if } 0 < T \leq t_{\mathrm{trunc}} \\
+0, & \text{otherwise}
+\end{cases}
+\]
+\begin{eqnarray}
+T & = & \tage - t \nonumber \\
+t_q & = & \tage - t_{\mathrm{trunc}} \nonumber
+\end{eqnarray}
+So now we have
+\begin{eqnarray}
+s_i  & = & \tintegral \, K \, (\tage-t) \, e^{(t-\tage) /\tau}\, \frac{\log t_{i+1} - \log t}{\dlt}  \nonumber \\
+      & = & \frac{K \, e^{-\tage/\tau}}{\dlt} \tintegral \, \left(\tage \, \log t_{i+1} \, e^{t/\tau}  - \tage \, \log t \, e^{t/\tau} - t \, \log t_{i+1} \, e^{t/\tau} + t \, \log t \, e^{t/\tau}\right) \quad .\nonumber
+\end{eqnarray}
+The first and third terms are fairly straightforward.  The second term is basically the integral we did for the $\tau$-model.  The last term can be solved by integrating by parts (with $u=t\,\log t$, $dv=e^{t/\tau}dt$ and hence $du=(\log e + \log t)\, dt$, $v=\tau e^{t/\tau}$.  Substituting and collecting terms gives, finally, 
+\begin{eqnarray}
+s_i  & = & \frac{K \, \tau \,  e^{-\tage/\tau}}{\dlt} \left[\left.\left(t\,\log \frac{t}{t_{i+1}} + \tage\,\log t_{i+1}  + \tau\,\log \frac{t_{i+1}}{e}\right) e^{t/\tau}\tinterval - (\tage/\tau+1)\, H_i\right] \quad .
+\end{eqnarray}
+
+For interpolation in linear time, we have
+\begin{eqnarray}
+g_i  & = & \tintegral \, K \, (\tage-t) \, e^{(t-\tage) /\tau}\, \frac{t_{i+1} - t}{\dt}  \nonumber \\
+      & = & \frac{K \, e^{-\tage/\tau}}{\dt} \tintegral \, \left(\tage \, t_{i+1} \, e^{t/\tau}  - \tage \, t \, e^{t/\tau} - t \,  t_{i+1} \, e^{t/\tau} + t^2 \, e^{t/\tau}\right) \nonumber \\
+     & = & \frac{K \, \tau \, e^{-\tage/\tau}}{\dt} \left. e^{t/\tau} \, \left[ \tage \, t_{i+1} - (\tage + t_{i+1})\, (t-\tau) + t^2 - 2\, t\, \tau + 2\, \tau^2\right] \tinterval \quad .
+\end{eqnarray}
+
+\subsection{Simha}
+This is the SFH from \citet{simha14}.  It is defined by a delayed-$\tau$ SFH until some time $\sftrunc$, after which the SFH is linearly increasing or decreasing with some slope $m_{\mathrm{SF}}$.  The SFR is continuous at $\sftrunc$, but the derivative is not.  For this reason, we will treat the SFH in two separate pieces.  The trick is to get the proper normalization at $\sftrunc$ and, for linearly decreasing SF, find the time where the SF reaches zero. 
+
+
+\subsection{Bursts}
 
 \end{document}

--- a/doc/text/sfhs.tex
+++ b/doc/text/sfhs.tex
@@ -88,8 +88,9 @@ The key in both cases is to properly calculate $\tmax$ and keep track of the ind
 \section{Lookback Time Zero}
 The youngest age for which an SSP spectrum is availables is generally of order 1 Myr.  
 However, we need to account for SF occuring from 0-1 Myr lookback time.
-There's a couple ways to deal with this.  
-Probably the most straightforward is to simply approximate the $t=0$ spectrum by the youngest available SSP.
+There's a couple ways to deal with this necessary extrapolation.
+Probably the most straightforward is nearest-neighbor extrapolation.  
+That is, simply approximate the $t=0$ spectrum by the youngest available SSP.
 
 In the case of logarithmic interpolation one has to define some minimum age, say 1 year, to act as zero.
 In practice the exact choice of minimum age does not matter, 
@@ -232,6 +233,7 @@ g_i  & = & \tintegral \,  L\, \left[1 - \sfslope \, (t_q - t)\right] \, \frac{t_
       & = & \frac{L}{\dt} \left.\left[(1-\sfslope\, t_q) \, t_{i+1} \, t + \left(\sfslope\, t_{i+1} + \sfslope \, t_q -1\right)\, \frac{t^2}{2} - \frac{\sfslope\, t^3}{3}\right] \tinterval
 \end{eqnarray}
 
+We verify that these expressions reduce to the constant SFR case when $\sfslope=0$.
 
 \subsection{Bursts}
 

--- a/doc/text/sfhs.tex
+++ b/doc/text/sfhs.tex
@@ -1,0 +1,48 @@
+\documentclass[12pt, letterpaper, preprint]{aastex} 
+
+\usepackage{graphicx}
+
+\newcommand{\tmin}[1][]{t_{\mathrm{min} #1}}
+\newcommand{\tmax}[1][]{t_{\mathrm{max} #1}}
+\newcommand{\amin}{a_{\mathrm{min}}}
+\newcommand{\amax} {a_{\mathrm{max}}}
+
+\begin{document}
+\author{B. Johnson}
+
+\begin{center}
+\today
+\end{center}
+
+We wish to find the proper weighting of discrete SSPs to reproduce the spectrum from SFR occurring within some bin of  lookback times $(\amin, \amax)$.
+If we approximate the spectrum at any lookback time $t$ as a linear interpolation of the spectra at the discrete SSP lookback times $t_i$, for $i=1,...,N$ then we can write the total contribution of SSP $i$ to the total spectrum as a sum of the integrated weight due to SF in the sub-bin to the ``right'' (higher lookback times) and the  sub-bin to the ``left'' (lower lookback times).
+The sub-bins are defined by the spacing of the SSP $t_i$ values. 
+The limits of each integral are determined either by the spacing of the SSP points $t_i$ or, when the bin does not completely span the sub-bin, by the $\amin$ and/or $\amax$ values.
+\begin{eqnarray}
+w_i & = & w_{i, \mathrm{right}} + w_{i, \mathrm{left}} \\
+w_{i, \mathrm{right}} & = & \int_{\tmin[,i]}^{\tmax[,i]} dt \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \\
+w_{i, \mathrm{left}} & = & \int_{\tmin[,i-1]}^{\tmax[,i-1]} dt \, \mathrm{SFR}(t) \, \frac{t - t_{i-1}}{t_{i}  - t_{i-1}} \\
+\tmin[,i] & = & \sup (t_i, \amin) \\
+\tmax[,i] & = & \inf (t_{i+1}, \amax) \\
+\end{eqnarray}
+If we take $\mathrm{SFR}(t) = 1$ then we can define
+\begin{eqnarray}
+s_i & \equiv & \int_{\tmin[,i]}^{\tmax[,i]} dt \, \mathrm{SFR}(t) \, \frac{t_{i+1} - t}{t_{i+1}  - t_i} \\
+ & = & \left. \frac{1}{t_{i+1} - t_i} \, \left[ t_{i+1} \, t - \frac{t^2}{2} \right] \right| _{\tmin[,i]}^{\tmax[,i]}
+\end{eqnarray}
+which leads to
+\begin{eqnarray}
+w_i & = & s_{i} - s_{i-1}
+\end{eqnarray}
+and one only has to calculate the $s_i$ once and then take differences between shifted versions to obtain the total weights. 
+
+In the case of a linear interpolation in $\log t$, which is probably more appropriate, we would simply replace $s_i$ by 
+\begin{eqnarray}
+s_i & \equiv & \int_{\tmin[,i]}^{\tmax[,i]} dt \, \mathrm{SFR}(t) \, \frac{\log t_{i+1} - \log t}{\log t_{i+1}  - \log t_i} \\
+ & = & \left. \frac{1}{\log t_{i+1} - \log t_i} \left[ t \, \log t_{i+1} - t \log\left(\frac{t}{e}\right) \right] \right|_{\tmin[,i]}^{\tmax[,i]}
+\end{eqnarray}
+
+The key in both cases is to properly calculate $\tmax$ and keep track of the indices (especially for the first and last SSP, where $s_{i-1}$ and $s_i$ are not defined, respectively.)  
+For more complicated SFH the integrals in the definition of $s_i$ must be calculated (remembering here that $t$ is \emph{lookback} time.)
+
+\end{document}

--- a/misc/test_compsp.py
+++ b/misc/test_compsp.py
@@ -21,7 +21,7 @@ sspages = np.insert(mysps.logage, 0, 0)
 
 
 def main():
-    figlist = test_taumodel_dust(sfh=1)
+    figlist = test_taumodel_sft(sfh=5)
     pl.show()
 
 def test_mint_convergence():
@@ -29,13 +29,13 @@ def test_mint_convergence():
      """
     sfh_params = {'tage': 1e9, 'tau':14e9}
     # set up an array of minimum values, and get the weights for each minimum value
-    mint = 10**np.linspace(-4, 2, 100)
+    mint = np.linspace(-4, 2, 100)
     w = np.zeros([len(mint), len(mysps.logage)+1])
     for i, m in enumerate(mint):
         mysps.update(**sfh_params)
         mysps.mint_log = m
         mysps.configure()
-        w[i,:] = mysps.ssp_weights
+        w[i,:] = mysps.all_ssp_weights
 
     # Plot summed weight for zeroth and 1st SSP
     pl.figure()
@@ -53,8 +53,16 @@ def test_mint_convergence():
 def test_normalization():
     sfh_params = {'tage': 1e9, 'tau':14e9}
     mtot = None
-    w = mysps.ssp_weights
+    w = mysps.all_ssp_weights
 
+
+def test_simha(values=np.linspace(0.0, 4.0, 9), tage=3.0):
+    pname = r'sf_trunc'
+    sps.params['sfh'] = 5
+    mysps.sfh_type = sfhtype[sfh]
+    mysps.configure()
+    sfig, saxes = pl.subplots(2, 1, figsize=(11, 8.5))
+    #for sf_trunc in 
 
 def test_taumodel_dust(values=np.linspace(0.0, 4.0, 9),
                        tage=3.0, tau=1.0, sfh=1):
@@ -74,20 +82,20 @@ def test_taumodel_dust(values=np.linspace(0.0, 4.0, 9),
         mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
         rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, dust2))
         dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, dust2))
-        #wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, dust2))
+        #wax.plot(sspages, mysps.all_ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, dust2))
     rax.set_xlim(1e3, 1e7)
     rax.set_ylabel('pro / FSPS')
     dax.set_xlim(1e3, 1e7)
     dax.set_ylabel('FSPS - pro')
     [ax.set_xscale('log') for ax in [rax, dax]]
     [ax.legend(loc=0, prop={'size': 10}) for ax in [rax, dax]]
-    [ax.text(0.1, 0.85, '$\tau_{{SF}}={}, tage={}$'.format(tau, tage), transform=ax.transAxes)
+    [ax.text(0.1, 0.85, r'$\tau_{{SF}}={}, tage={}$'.format(tau, tage), transform=ax.transAxes)
      for ax in [rax, dax]]
     #wax.set_yscale('log')
     #wax.set_xlabel('log t$_{lookback}$')
     #wax.set_ylabel('weight')
     [ax.set_title('SFH={} ({} model)'.format(sfh, sfhtype[sfh]))
-     for ax in [rax, wax]]
+     for ax in [rax]]
     return [sfig]
     
     
@@ -110,7 +118,7 @@ def test_taumodel_tau(values=10**np.linspace(-1, 1, 9),
         mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
         rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, tau))
         dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, tau))
-        wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, tau))
+        wax.plot(sspages, mysps.all_ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, tau))
     rax.set_xlim(1e3, 2e4)
     rax.set_ylabel('pro / FSPS')
     dax.set_xlim(1e3, 2e4)
@@ -142,7 +150,7 @@ def test_taumodel_tage(values=10**np.linspace(np.log10(0.11), 1, 9),
         mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
         rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, tage))
         dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, tage))
-        wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, tage))
+        wax.plot(sspages, mysps.all_ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, tage))
     rax.set_xlim(1e3, 2e4)
     rax.set_ylabel('pro / FSPS')
     dax.set_xlim(1e3, 2e4)
@@ -175,13 +183,15 @@ def test_taumodel_sft(values=11 - 10**np.linspace(np.log10(0.11), 1, 9),
         mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
         rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, sf_trunc))
         dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, sf_trunc))
-        wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, sf_trunc))
+        wax.plot(sspages, mysps.all_ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, sf_trunc))
         wax.axvline(np.log10((tage - sf_trunc) * 1e9), linestyle=':', color='k')
     rax.set_xlim(1e3, 2e4)
     rax.set_ylabel('pro / FSPS')
     dax.set_xlim(1e3, 2e4)
     dax.set_ylabel('FSPS - pro')
     [ax.legend(loc=0, prop={'size': 10}) for ax in [rax, dax, wax]]
+    [ax.text(0.1, 0.85, r'$\tau_{{SF}}={}, tage={}$'.format(tau, tage), transform=ax.transAxes)
+     for ax in [rax, dax, wax]]
     wax.set_yscale('log')
     wax.set_xlabel('log t$_{lookback}$')
     wax.set_ylabel('weight')

--- a/misc/test_compsp.py
+++ b/misc/test_compsp.py
@@ -1,0 +1,195 @@
+# Test the analytic full SFR integrals implemented in SSPBasis against the
+# COMPSP implementations of same.
+
+import sys, os, time
+import numpy as np
+import matplotlib.pyplot as pl
+import fsps
+from bsfh.source_basis import CompositeSFH
+
+sfhtype = {1:'tau', 4: 'delaytau', 5: 'simha'}
+
+
+compute_vega_mags = False
+zcontinuous = 1
+sps = fsps.StellarPopulation(compute_vega_mags=compute_vega_mags,
+                             zcontinuous=zcontinuous)
+mysps = CompositeSFH(sfh_type='tau', interp_type='logarithmic', flux_interp='linear',
+                     compute_vega_mags=compute_vega_mags, zcontinuous=zcontinuous)
+mysps.configure()
+sspages = np.insert(mysps.logage, 0, 0)
+
+
+def main():
+    figlist = test_taumodel_dust(sfh=1)
+    pl.show()
+
+def test_mint_convergence():
+    """Test convergence of most recent bin.
+     """
+    sfh_params = {'tage': 1e9, 'tau':14e9}
+    # set up an array of minimum values, and get the weights for each minimum value
+    mint = 10**np.linspace(-4, 2, 100)
+    w = np.zeros([len(mint), len(mysps.logage)+1])
+    for i, m in enumerate(mint):
+        mysps.update(**sfh_params)
+        mysps.mint_log = m
+        mysps.configure()
+        w[i,:] = mysps.ssp_weights
+
+    # Plot summed weight for zeroth and 1st SSP
+    pl.figure()
+    zero = (w[:,0] + w[:,1])
+    pl.plot(mint, zero, '-o')
+    pl.yscale('log')
+    pl.show()
+
+    # Plot fractional weight error (relative to smallest tmin) as a function of tmin
+    pl.figure()
+    pl.plot(np.log10(mint), 1 - w[:,0]/w[0,0], '-o')
+    pl.plot(np.log10(mint), 1 - w[:,1]/w[0,1], '-o')
+    pl.show()
+
+def test_normalization():
+    sfh_params = {'tage': 1e9, 'tau':14e9}
+    mtot = None
+    w = mysps.ssp_weights
+
+
+def test_taumodel_dust(values=np.linspace(0.0, 4.0, 9),
+                       tage=3.0, tau=1.0, sfh=1):
+    pname = r'$\tau_V$'
+    sps.params['sfh'] = sfh
+    mysps.sfh_type = sfhtype[sfh]
+    mysps.configure()
+    sfig, saxes = pl.subplots(2, 1, figsize=(11, 8.5))
+    rax, dax = saxes
+    #wfig, wax = pl.subplots()
+    for dust2 in values:
+        sps.params['tau'] = tau
+        sps.params['tage'] = tage
+        sps.params['dust2'] = dust2
+        sfh_params = {'tage': tage*1e9, 'tau': tau*1e9, 'dust2': dust2}
+        w, spec = sps.get_spectrum(tage=tage, peraa=True)
+        mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
+        rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, dust2))
+        dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, dust2))
+        #wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, dust2))
+    rax.set_xlim(1e3, 1e7)
+    rax.set_ylabel('pro / FSPS')
+    dax.set_xlim(1e3, 1e7)
+    dax.set_ylabel('FSPS - pro')
+    [ax.set_xscale('log') for ax in [rax, dax]]
+    [ax.legend(loc=0, prop={'size': 10}) for ax in [rax, dax]]
+    [ax.text(0.1, 0.85, '$\tau_{{SF}}={}, tage={}$'.format(tau, tage), transform=ax.transAxes)
+     for ax in [rax, dax]]
+    #wax.set_yscale('log')
+    #wax.set_xlabel('log t$_{lookback}$')
+    #wax.set_ylabel('weight')
+    [ax.set_title('SFH={} ({} model)'.format(sfh, sfhtype[sfh]))
+     for ax in [rax, wax]]
+    return [sfig]
+    
+    
+def test_taumodel_tau(values=10**np.linspace(-1, 1, 9),
+                      tage=10.0, sfh=1):
+    """Test (delayed-) tau models
+    """
+    pname = '$\tau$'
+    sps.params['sfh'] = sfh
+    mysps.sfh_type = sfhtype[sfh]
+    mysps.configure()
+    sfig, saxes = pl.subplots(2, 1, figsize=(11, 8.5))
+    rax, dax = saxes
+    wfig, wax = pl.subplots()
+    for tau in values:
+        sps.params['tau'] = tau
+        sps.params['tage'] = tage
+        sfh_params = {'tage': tage*1e9, 'tau': tau*1e9}
+        w, spec = sps.get_spectrum(tage=tage, peraa=True)
+        mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
+        rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, tau))
+        dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, tau))
+        wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, tau))
+    rax.set_xlim(1e3, 2e4)
+    rax.set_ylabel('pro / FSPS')
+    dax.set_xlim(1e3, 2e4)
+    dax.set_ylabel('FSPS - pro')
+    [ax.legend(loc=0, prop={'size': 10}) for ax in [rax, dax, wax]]
+    wax.set_yscale('log')
+    wax.set_xlabel('log t$_{lookback}$')
+    wax.set_ylabel('weight')
+    [ax.set_title('SFH={} ({} model)'.format(sfh, sfhtype[sfh]))
+     for ax in [rax, wax]]
+    return [sfig, wfig]
+
+def test_taumodel_tage(values=10**np.linspace(np.log10(0.11), 1, 9),
+                       tau=1.0, sfh=1):
+    """Test (delayed-) tau models
+    """
+    pname = 'tage'
+    sps.params['sfh'] = sfh
+    mysps.sfh_type = sfhtype[sfh]
+    mysps.configure()
+    sfig, saxes = pl.subplots(2, 1, figsize=(11, 8.5))
+    rax, dax = saxes
+    wfig, wax = pl.subplots()
+    for tage in values:
+        sps.params['tau'] = tau
+        sps.params['tage'] = tage
+        sfh_params = {'tage': tage*1e9, 'tau': tau*1e9}
+        w, spec = sps.get_spectrum(tage=tage, peraa=True)
+        mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
+        rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, tage))
+        dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, tage))
+        wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, tage))
+    rax.set_xlim(1e3, 2e4)
+    rax.set_ylabel('pro / FSPS')
+    dax.set_xlim(1e3, 2e4)
+    dax.set_ylabel('FSPS - pro')
+    [ax.legend(loc=0, prop={'size': 10}) for ax in [rax, dax, wax]]
+    wax.set_yscale('log')
+    wax.set_xlabel('log t$_{lookback}$')
+    wax.set_ylabel('weight')
+    [ax.set_title('SFH={} ({} model)'.format(sfh, sfhtype[sfh]))
+     for ax in [rax, wax]]
+    return [sfig, wfig]
+
+def test_taumodel_sft(values=11 - 10**np.linspace(np.log10(0.11), 1, 9),
+                      tau=1.0, tage=11.0, sfh=1):
+    """Test (delayed-) tau models
+    """
+    pname = 'sf_trunc'
+    sps.params['sfh'] = sfh
+    mysps.sfh_type = sfhtype[sfh]
+    mysps.configure()
+    sfig, saxes = pl.subplots(2, 1, figsize=(11, 8.5))
+    rax, dax = saxes
+    wfig, wax = pl.subplots()
+    for sf_trunc in values:
+        sps.params['tau'] = tau
+        sps.params['tage'] = tage
+        sps.params['sf_trunc'] = sf_trunc
+        sfh_params = {'tage': tage*1e9, 'tau': tau*1e9, 'sf_trunc': sf_trunc*1e9}
+        w, spec = sps.get_spectrum(tage=tage, peraa=True)
+        mw, myspec = mysps.get_galaxy_spectrum(**sfh_params)
+        rax.plot(mw, myspec / spec, label=r'{}={:4.2f}'.format(pname, sf_trunc))
+        dax.plot(mw, spec - myspec, label=r'{}={:4.2f}'.format(pname, sf_trunc))
+        wax.plot(sspages, mysps.ssp_weights, '-o', label=r'{}={:4.2f}'.format(pname, sf_trunc))
+        wax.axvline(np.log10((tage - sf_trunc) * 1e9), linestyle=':', color='k')
+    rax.set_xlim(1e3, 2e4)
+    rax.set_ylabel('pro / FSPS')
+    dax.set_xlim(1e3, 2e4)
+    dax.set_ylabel('FSPS - pro')
+    [ax.legend(loc=0, prop={'size': 10}) for ax in [rax, dax, wax]]
+    wax.set_yscale('log')
+    wax.set_xlabel('log t$_{lookback}$')
+    wax.set_ylabel('weight')
+    logttrunc = np.log10((tage - values) * 1e9)
+    wax.set_xlim(logttrunc.min() - 0.5, logttrunc.max() + 0.5)
+    [ax.set_title('SFH={} ({} model)'.format(sfh, sfhtype[sfh]))
+     for ax in [rax, wax]]
+    return [sfig, wfig]
+
+if __name__ == "__main__":
+    main()

--- a/misc/test_stepsfh.py
+++ b/misc/test_stepsfh.py
@@ -1,0 +1,27 @@
+import matplotlib.pyplot as pl
+import numpy as np
+from bsfh.source_basis import ssp_basis
+
+sps = ssp_basis.StepSFHBasis(interp_type='logarithmic')
+
+nbin = 7
+ages = np.linspace(7, 10, nbin+1)
+params = {'agebins': np.array([ages[:-1], ages[1:]]).T,
+          'mass': 10**ages[1:] - 10**ages[:-1] }
+
+
+sps.update(**params)
+
+w = sps.ssp_weights
+
+pl.plot(sps.logage, w)
+agebins = sps.params['agebins']
+masses = sps.params['mass']
+#w = np.zeros(len(self.logage))
+for (t1, t2), mass in zip(agebins, masses):
+    print(t1, t2, mass)
+    pl.axvline(t1, linestyle=':')
+    pl.plot(sps.logage, sps.bin_weights(t1, t2)[1:])
+
+
+spec, phot, x = sps.get_spectrum(**params)


### PR DESCRIPTION
Introduce classes to source_basis that produce spectra from composite SFHs, including piecewise constant.  These spectra are produced by analytically integrating the interpolation weights for the SSPs, weighted again by the SFR.  A tex document details the math for each of the supported SFHs forms.  Tests are introduced that compare the resulting spectra to those produced by compsp.f90 in FSPS.